### PR TITLE
Correct composer metadata and keywords

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,14 +1,14 @@
 {
     "name": "flexmind-software/currency-rate",
-    "vesrion": "0.1.1",
+    "version": "0.1.1",
     "description": "Library download currency rate and save in database, It's designed to be extended by any available data source.",
     "keywords": [
         "flexmind",
         "laravel",
-        "pachages",
+        "packages",
         "php",
         "mysql",
-        "postresql",
+        "postgresql",
         "mongo",
         "currency-converter",
         "currency-exchange",
@@ -72,6 +72,6 @@
             }
         }
     },
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "prefer-stable": true
 }


### PR DESCRIPTION
## Summary
- fix `version` key typo in composer.json
- correct keyword spellings and set minimum stability to stable

## Testing
- `composer validate`


------
https://chatgpt.com/codex/tasks/task_e_68a54f464f4c8333851da3d2c61a76d0