### PR TITLE
Make queue job ID configurable and log failures

### DIFF
--- a/testbench.yaml
+++ b/testbench.yaml
@@ -1,2 +1,2 @@
 providers:
-  - FlexMindSoftware\CurrencyRate\SkeletonServiceProvider
+  - FlexMindSoftware\CurrencyRate\CurrencyRateServiceProvider

--- a/tests/QueueDownloadTest.php
+++ b/tests/QueueDownloadTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace FlexMindSoftware\CurrencyRate\Tests;
+
+use DateTime;
+use FlexMindSoftware\CurrencyRate\Jobs\QueueDownload;
+use Illuminate\Support\Facades\Log;
+
+class QueueDownloadTest extends TestCase
+{
+    /** @test */
+    public function handle_logs_exception()
+    {
+        Log::shouldReceive('error')->once();
+
+        $job = new QueueDownload('fake', new DateTime(), 'testing');
+
+        $job->handle();
+        $this->assertTrue(true);
+    }
+}


### PR DESCRIPTION
## Summary
- derive queue job unique ID from app name instead of hardcoded prefix
- wrap currency rate download job in try/catch and log failures
- test that job gracefully handles exceptions

## Testing
- `composer test`
- `composer psalm` *(fails: Class "CurrencyRate" not found and other issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a54f660f2083339b5fad36ad1baa97