### PR TITLE
feat: introduce HTTP fetcher trait and unify drivers

### DIFF
--- a/src/Drivers/ArmeniaDriver.php
+++ b/src/Drivers/ArmeniaDriver.php
@@ -7,7 +7,6 @@ use DateTime;
 use FlexMindSoftware\CurrencyRate\Contracts\CurrencyInterface;
 use FlexMindSoftware\CurrencyRate\Models\Currency;
 use FlexMindSoftware\CurrencyRate\Models\RateTrait;
-use Illuminate\Support\Facades\Http;
 
 /**
  *
@@ -40,9 +39,9 @@ class ArmeniaDriver extends BaseDriver implements CurrencyInterface
      */
     public function grabExchangeRates(): self
     {
-        $response = Http::get(static::URI, $this->queryString($this->date));
-        if ($response->ok()) {
-            $this->csvPlain = $response->body();
+        $response = $this->fetch(static::URI, $this->queryString($this->date));
+        if ($response) {
+            $this->csvPlain = $response;
             $this->parseResponse();
         }
 
@@ -77,10 +76,7 @@ class ArmeniaDriver extends BaseDriver implements CurrencyInterface
     {
         $this->data = [];
 
-        $lines = explode("\n", $this->csvPlain);
-        $lines = array_map(function ($item) {
-            return explode(',', $item);
-        }, $lines);
+        $lines = $this->parseCsv($this->csvPlain, ',');
         $head = head($lines);
         $head[0] = null;
 

--- a/src/Drivers/AustraliaDriver.php
+++ b/src/Drivers/AustraliaDriver.php
@@ -5,7 +5,6 @@ namespace FlexMindSoftware\CurrencyRate\Drivers;
 use FlexMindSoftware\CurrencyRate\Contracts\CurrencyInterface;
 use FlexMindSoftware\CurrencyRate\Models\Currency;
 use FlexMindSoftware\CurrencyRate\Models\RateTrait;
-use Illuminate\Support\Facades\Http;
 
 class AustraliaDriver extends BaseDriver implements CurrencyInterface
 {
@@ -34,9 +33,9 @@ class AustraliaDriver extends BaseDriver implements CurrencyInterface
      */
     public function grabExchangeRates(): self
     {
-        $respond = Http::get(static::URI);
-        if ($respond->ok()) {
-            $this->xml = $respond->body();
+        $respond = $this->fetch(static::URI);
+        if ($respond) {
+            $this->xml = $respond;
             $this->parseResponse();
         }
 
@@ -45,7 +44,7 @@ class AustraliaDriver extends BaseDriver implements CurrencyInterface
 
     private function parseResponse()
     {
-        $xml = simplexml_load_string($this->xml, "SimpleXMLElement", LIBXML_NOCDATA);
+        $xml = $this->parseXml($this->xml);
         $json = json_decode(json_encode($xml), true);
 
         $currencyList = [];

--- a/src/Drivers/AzerbaijanDriver.php
+++ b/src/Drivers/AzerbaijanDriver.php
@@ -6,7 +6,6 @@ use DateTime;
 use FlexMindSoftware\CurrencyRate\Contracts\CurrencyInterface;
 use FlexMindSoftware\CurrencyRate\Models\Currency;
 use FlexMindSoftware\CurrencyRate\Models\RateTrait;
-use Illuminate\Support\Facades\Http;
 
 class AzerbaijanDriver extends BaseDriver implements CurrencyInterface
 {
@@ -35,9 +34,9 @@ class AzerbaijanDriver extends BaseDriver implements CurrencyInterface
      */
     public function grabExchangeRates(): self
     {
-        $respond = Http::get(static::URI, ['date_req' => $this->date->format('d.m.Y')]);
-        if ($respond->ok()) {
-            $this->xml = $respond->body();
+        $respond = $this->fetch(static::URI, ['date_req' => $this->date->format('d.m.Y')]);
+        if ($respond) {
+            $this->xml = $respond;
             $this->parseResponse();
         }
 
@@ -46,7 +45,7 @@ class AzerbaijanDriver extends BaseDriver implements CurrencyInterface
 
     private function parseResponse()
     {
-        $xmlElement = simplexml_load_string($this->xml, "SimpleXMLElement", LIBXML_NOCDATA);
+        $xmlElement = $this->parseXml($this->xml);
         $json = json_decode(json_encode($xmlElement), true);
         $date = DateTime::createFromFormat('d.m.Y', $json['@attributes']['Date'])->format('Y-m-d');
 

--- a/src/Drivers/BaseDriver.php
+++ b/src/Drivers/BaseDriver.php
@@ -9,6 +9,7 @@ use FlexMindSoftware\CurrencyRate\Models\CurrencyRate;
 
 abstract class BaseDriver
 {
+    use HttpFetcher;
     /**
      * @var DateTime
      */

--- a/src/Drivers/BceaoDriver.php
+++ b/src/Drivers/BceaoDriver.php
@@ -8,7 +8,6 @@ use DOMXPath;
 use FlexMindSoftware\CurrencyRate\Contracts\CurrencyInterface;
 use FlexMindSoftware\CurrencyRate\Models\Currency;
 use FlexMindSoftware\CurrencyRate\Models\RateTrait;
-use Illuminate\Support\Facades\Http;
 
 class BceaoDriver extends BaseDriver implements CurrencyInterface
 {
@@ -38,9 +37,9 @@ class BceaoDriver extends BaseDriver implements CurrencyInterface
     {
         $exists = false;
         do {
-            $respond = Http::get(static::URI, $this->queryString());
-            if ($respond->ok()) {
-                $this->html = '<head><meta charset="utf-8" /></head><body>' . $respond->body() . '</body>';
+            $respond = $this->fetch(static::URI, $this->queryString());
+            if ($respond) {
+                $this->html = '<head><meta charset="utf-8" /></head><body>' . $respond . '</body>';
                 $this->xpath = $this->htmlParse();
                 if (! ($exists = $this->xpath->query('//table')->count() > 0)) {
                     $this->date->sub(DateInterval::createFromDateString('1 day'));

--- a/src/Drivers/BelarusDriver.php
+++ b/src/Drivers/BelarusDriver.php
@@ -6,7 +6,6 @@ use DateTime;
 use FlexMindSoftware\CurrencyRate\Contracts\CurrencyInterface;
 use FlexMindSoftware\CurrencyRate\Models\Currency;
 use FlexMindSoftware\CurrencyRate\Models\RateTrait;
-use Illuminate\Support\Facades\Http;
 
 /**
  *
@@ -39,10 +38,10 @@ class BelarusDriver extends BaseDriver implements CurrencyInterface
      */
     public function grabExchangeRates(): self
     {
-        $response = Http::get(static::URI, $this->queryString());
+        $response = $this->fetch(static::URI, $this->queryString());
 
-        if ($response->ok()) {
-            $this->xml = $response->body();
+        if ($response) {
+            $this->xml = $response;
             $this->parseResponse();
         }
 
@@ -64,7 +63,7 @@ class BelarusDriver extends BaseDriver implements CurrencyInterface
      */
     private function parseResponse()
     {
-        $xml = simplexml_load_string($this->xml);
+        $xml = $this->parseXml($this->xml);
 
         if (count($xml->Currency)) {
             $date = DateTime::createFromFormat('m/d/Y', $xml->attributes()[0])->format('Y-m-d');

--- a/src/Drivers/BosniaAndHerzegovinaDriver.php
+++ b/src/Drivers/BosniaAndHerzegovinaDriver.php
@@ -5,7 +5,6 @@ namespace FlexMindSoftware\CurrencyRate\Drivers;
 use FlexMindSoftware\CurrencyRate\Contracts\CurrencyInterface;
 use FlexMindSoftware\CurrencyRate\Models\Currency;
 use FlexMindSoftware\CurrencyRate\Models\RateTrait;
-use Illuminate\Support\Facades\Http;
 
 /**
  *
@@ -37,9 +36,9 @@ class BosniaAndHerzegovinaDriver extends BaseDriver implements CurrencyInterface
      */
     public function grabExchangeRates(): self
     {
-        $response = Http::asJson()->get(static::URI, $this->getQueryString());
-        if ($response->ok()) {
-            $this->jsonData = $response->json();
+        $response = $this->fetch(static::URI, $this->getQueryString());
+        if ($response) {
+            $this->jsonData = json_decode($response, true);
             $this->parseResponse();
         }
 

--- a/src/Drivers/BotswanaDriver.php
+++ b/src/Drivers/BotswanaDriver.php
@@ -6,7 +6,6 @@ use DateTime;
 use FlexMindSoftware\CurrencyRate\Contracts\CurrencyInterface;
 use FlexMindSoftware\CurrencyRate\Models\Currency;
 use FlexMindSoftware\CurrencyRate\Models\RateTrait;
-use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 
 class BotswanaDriver extends BaseDriver implements CurrencyInterface
@@ -37,9 +36,9 @@ class BotswanaDriver extends BaseDriver implements CurrencyInterface
     public function grabExchangeRates(): self
     {
         try {
-            $respond = Http::get(static::URI, $this->queryString());
-            if ($respond->ok()) {
-                $this->csv = $respond->body();
+            $respond = $this->fetch(static::URI, $this->queryString());
+            if ($respond) {
+                $this->csv = $respond;
                 $this->parseResponse();
             }
         } catch (\Throwable $e) {
@@ -66,8 +65,7 @@ class BotswanaDriver extends BaseDriver implements CurrencyInterface
 
     private function parseResponse()
     {
-        $csv = explode("\n", $this->csv);
-        $csv = array_map('str_getcsv', $csv);
+        $csv = $this->parseCsv($this->csv);
 
         $headers = head($csv);
 

--- a/src/Drivers/BulgariaDriver.php
+++ b/src/Drivers/BulgariaDriver.php
@@ -6,7 +6,6 @@ use DateTime;
 use FlexMindSoftware\CurrencyRate\Contracts\CurrencyInterface;
 use FlexMindSoftware\CurrencyRate\Models\Currency;
 use FlexMindSoftware\CurrencyRate\Models\RateTrait;
-use Illuminate\Support\Facades\Http;
 
 /**
  *
@@ -33,16 +32,10 @@ class BulgariaDriver extends BaseDriver implements CurrencyInterface
      */
     public function grabExchangeRates(): self
     {
-        $response = Http::get(static::URI, $this->queryString());
+        $fileContent = $this->fetch(static::URI, $this->queryString());
 
-        if ($response->ok()) {
-            $fileContent = $response->body();
-
-            $explode = explode("\n", $fileContent);
-
-            $rateList = array_map(function ($item) {
-                return explode(',', $item);
-            }, $explode);
+        if ($fileContent) {
+            $rateList = $this->parseCsv($fileContent, ',');
 
             $rateList = array_filter($rateList, function ($item) {
                 return count($item) === 6;

--- a/src/Drivers/CanadaDriver.php
+++ b/src/Drivers/CanadaDriver.php
@@ -6,7 +6,6 @@ use DateInterval;
 use FlexMindSoftware\CurrencyRate\Contracts\CurrencyInterface;
 use FlexMindSoftware\CurrencyRate\Models\Currency;
 use FlexMindSoftware\CurrencyRate\Models\RateTrait;
-use Illuminate\Support\Facades\Http;
 
 /**
  *
@@ -47,9 +46,9 @@ class CanadaDriver extends BaseDriver implements CurrencyInterface
     {
         do {
             $url = $this->sourceUrl();
-            $response = Http::get($url);
-            if ($response->ok()) {
-                $this->jsonFile = $response->json();
+            $response = $this->fetch($url);
+            if ($response) {
+                $this->jsonFile = json_decode($response, true);
                 if (blank($this->jsonFile['observations'])) {
                     $this->date->sub(DateInterval::createFromDateString('1 day'));
                 }

--- a/src/Drivers/ChinaDriver.php
+++ b/src/Drivers/ChinaDriver.php
@@ -5,7 +5,6 @@ namespace FlexMindSoftware\CurrencyRate\Drivers;
 use FlexMindSoftware\CurrencyRate\Contracts\CurrencyInterface;
 use FlexMindSoftware\CurrencyRate\Models\Currency;
 use FlexMindSoftware\CurrencyRate\Models\RateTrait;
-use Illuminate\Support\Facades\Http;
 
 class ChinaDriver extends BaseDriver implements CurrencyInterface
 {
@@ -29,9 +28,9 @@ class ChinaDriver extends BaseDriver implements CurrencyInterface
      */
     public function grabExchangeRates(): self
     {
-        $respond = Http::get(static::URI, $this->queryString());
-        if ($respond->ok()) {
-            $this->json = $respond->json();
+        $respond = $this->fetch(static::URI, $this->queryString());
+        if ($respond) {
+            $this->json = json_decode($respond, true);
             $this->parseResponse();
         }
 

--- a/src/Drivers/CzechRepublicDriver.php
+++ b/src/Drivers/CzechRepublicDriver.php
@@ -6,7 +6,6 @@ use DateTime;
 use FlexMindSoftware\CurrencyRate\Contracts\CurrencyInterface;
 use FlexMindSoftware\CurrencyRate\Models\Currency;
 use FlexMindSoftware\CurrencyRate\Models\RateTrait;
-use Illuminate\Support\Facades\Http;
 
 /**
  *
@@ -47,9 +46,8 @@ class CzechRepublicDriver extends BaseDriver implements CurrencyInterface
     {
         $sourceUrl = $this->sourceUrl();
 
-        $response = Http::get($sourceUrl);
-        if ($response->ok()) {
-            $fileContent = $response->body();
+        $fileContent = $this->fetch($sourceUrl);
+        if ($fileContent) {
 
             $explode = explode("\n", $fileContent);
 

--- a/src/Drivers/DenmarkDriver.php
+++ b/src/Drivers/DenmarkDriver.php
@@ -5,7 +5,6 @@ namespace FlexMindSoftware\CurrencyRate\Drivers;
 use FlexMindSoftware\CurrencyRate\Contracts\CurrencyInterface;
 use FlexMindSoftware\CurrencyRate\Models\Currency;
 use FlexMindSoftware\CurrencyRate\Models\RateTrait;
-use Illuminate\Support\Facades\Http;
 
 /**
  *
@@ -36,11 +35,9 @@ class DenmarkDriver extends BaseDriver implements CurrencyInterface
      */
     public function grabExchangeRates(): self
     {
-        $response = Http::get($this->sourceUrl());
-        if ($response->ok()) {
-            $xml = $response->body();
-
-            $xml = simplexml_load_string($xml, "SimpleXMLElement", LIBXML_NOCDATA);
+        $response = $this->fetch($this->sourceUrl());
+        if ($response) {
+            $xml = $this->parseXml($response);
             $json = json_decode(json_encode($xml), true);
 
             $this->parseDate($json);

--- a/src/Drivers/DummyDriver.php
+++ b/src/Drivers/DummyDriver.php
@@ -5,7 +5,6 @@ namespace FlexMindSoftware\CurrencyRate\Drivers;
 use FlexMindSoftware\CurrencyRate\Contracts\CurrencyInterface;
 use FlexMindSoftware\CurrencyRate\Models\Currency;
 use FlexMindSoftware\CurrencyRate\Models\RateTrait;
-use Illuminate\Support\Facades\Http;
 
 class DummyDriver extends BaseDriver implements CurrencyInterface
 {
@@ -29,9 +28,9 @@ class DummyDriver extends BaseDriver implements CurrencyInterface
      */
     public function grabExchangeRates(): self
     {
-        $respond = Http::get(static::URI, $this->queryString());
-        if ($respond->ok()) {
-            $this->html = $respond->body();
+        $respond = $this->fetch(static::URI, $this->queryString());
+        if ($respond) {
+            $this->html = $respond;
             $this->parseResponse();
         }
 

--- a/src/Drivers/EnglandDriver.php
+++ b/src/Drivers/EnglandDriver.php
@@ -8,7 +8,6 @@ use DOMNodeList;
 use FlexMindSoftware\CurrencyRate\Contracts\CurrencyInterface;
 use FlexMindSoftware\CurrencyRate\Models\Currency;
 use FlexMindSoftware\CurrencyRate\Models\RateTrait;
-use Illuminate\Support\Facades\Http;
 
 class EnglandDriver extends BaseDriver implements CurrencyInterface
 {
@@ -42,9 +41,9 @@ class EnglandDriver extends BaseDriver implements CurrencyInterface
     public function grabExchangeRates(): self
     {
         do {
-            $respond = Http::get(static::URI, $this->queryString());
-            if ($respond->ok()) {
-                $xpath = $this->htmlParse($respond->body());
+            $respond = $this->fetch(static::URI, $this->queryString());
+            if ($respond) {
+                $xpath = $this->htmlParse($respond);
                 $this->tables = $xpath->query('//table');
             }
 

--- a/src/Drivers/EuropeanCentralBankDriver.php
+++ b/src/Drivers/EuropeanCentralBankDriver.php
@@ -6,7 +6,6 @@ use Exception;
 use FlexMindSoftware\CurrencyRate\Contracts\CurrencyInterface;
 use FlexMindSoftware\CurrencyRate\Models\Currency;
 use FlexMindSoftware\CurrencyRate\Models\RateTrait;
-use Illuminate\Support\Facades\Http;
 use SimpleXMLElement;
 
 class EuropeanCentralBankDriver extends BaseDriver implements CurrencyInterface
@@ -32,10 +31,9 @@ class EuropeanCentralBankDriver extends BaseDriver implements CurrencyInterface
      */
     public function grabExchangeRates(): self
     {
-        $respond = Http::get(static::URI);
-        if ($respond->ok()) {
-            $string = $respond->body();
-            $xml = new SimpleXMLElement($string);
+        $string = $this->fetch(static::URI);
+        if ($string) {
+            $xml = $this->parseXml($string);
 
             $this->parseDate($xml->Cube->Cube);
             $this->findByDate('date');

--- a/src/Drivers/FijiDriver.php
+++ b/src/Drivers/FijiDriver.php
@@ -5,7 +5,6 @@ namespace FlexMindSoftware\CurrencyRate\Drivers;
 use FlexMindSoftware\CurrencyRate\Contracts\CurrencyInterface;
 use FlexMindSoftware\CurrencyRate\Models\Currency;
 use FlexMindSoftware\CurrencyRate\Models\RateTrait;
-use Illuminate\Support\Facades\Http;
 use SimpleXLSX;
 
 class FijiDriver extends BaseDriver implements CurrencyInterface
@@ -42,9 +41,9 @@ class FijiDriver extends BaseDriver implements CurrencyInterface
      */
     public function grabExchangeRates(): self
     {
-        $respond = Http::get(static::URI . $this->urlString());
-        if ($respond->ok()) {
-            $this->html = $respond->body();
+        $respond = $this->fetch(static::URI . $this->urlString());
+        if ($respond) {
+            $this->html = $respond;
             $this->parseResponse();
         }
 

--- a/src/Drivers/GeorgiaDriver.php
+++ b/src/Drivers/GeorgiaDriver.php
@@ -6,7 +6,6 @@ use DateTime;
 use FlexMindSoftware\CurrencyRate\Contracts\CurrencyInterface;
 use FlexMindSoftware\CurrencyRate\Models\Currency;
 use FlexMindSoftware\CurrencyRate\Models\RateTrait;
-use Illuminate\Support\Facades\Http;
 
 class GeorgiaDriver extends BaseDriver implements CurrencyInterface
 {
@@ -42,9 +41,9 @@ class GeorgiaDriver extends BaseDriver implements CurrencyInterface
      */
     public function grabExchangeRates(): self
     {
-        $respond = Http::get(static::URI . 'en/json');
-        if ($respond->ok()) {
-            $this->json = $respond->json();
+        $respond = $this->fetch(static::URI . 'en/json');
+        if ($respond) {
+            $this->json = json_decode($respond, true);
 
             $this->getCurrencyList();
 
@@ -70,9 +69,9 @@ class GeorgiaDriver extends BaseDriver implements CurrencyInterface
     private function parseHistoricalDataResponse()
     {
         foreach ($this->currencyList as $currency) {
-            $respond = Http::get(static::URI, $this->queryString($this->date, $currency));
-            if ($respond->ok()) {
-                $this->json = $respond->json();
+            $respond = $this->fetch(static::URI, $this->queryString($this->date, $currency));
+            if ($respond) {
+                $this->json = json_decode($respond, true);
                 $this->parseCurrentDataResponse();
             }
         }

--- a/src/Drivers/HttpFetcher.php
+++ b/src/Drivers/HttpFetcher.php
@@ -33,4 +33,3 @@ trait HttpFetcher
         );
     }
 }
-

--- a/src/Drivers/HttpFetcher.php
+++ b/src/Drivers/HttpFetcher.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace FlexMindSoftware\CurrencyRate\Drivers;
+
+use Illuminate\Support\Facades\Http;
+use SimpleXMLElement;
+
+trait HttpFetcher
+{
+    protected function fetch(string $url, array $query = []): ?string
+    {
+        $response = Http::get($url, $query);
+
+        return $response->ok() ? $response->body() : null;
+    }
+
+    protected function parseXml(
+        string $xml,
+        int $options = LIBXML_NOCDATA,
+        string $ns = '',
+        bool $isPrefix = false
+    ): SimpleXMLElement {
+        return simplexml_load_string($xml, 'SimpleXMLElement', $options, $ns, $isPrefix);
+    }
+
+    protected function parseCsv(string $csv, string $delimiter = ';'): array
+    {
+        $lines = preg_split('/\r\n|\n|\r/', trim($csv));
+
+        return array_map(
+            fn ($line) => str_getcsv($line, $delimiter),
+            array_filter($lines)
+        );
+    }
+}
+

--- a/src/Drivers/HungaryDriver.php
+++ b/src/Drivers/HungaryDriver.php
@@ -7,7 +7,6 @@ use DOMXPath;
 use FlexMindSoftware\CurrencyRate\Contracts\CurrencyInterface;
 use FlexMindSoftware\CurrencyRate\Models\Currency;
 use FlexMindSoftware\CurrencyRate\Models\RateTrait;
-use Illuminate\Support\Facades\Http;
 
 class HungaryDriver extends BaseDriver implements CurrencyInterface
 {
@@ -37,9 +36,9 @@ class HungaryDriver extends BaseDriver implements CurrencyInterface
      */
     public function grabExchangeRates(): self
     {
-        $response = Http::get(static::URI, $this->queryString());
-        if ($response->ok()) {
-            $this->html = $response->body();
+        $response = $this->fetch(static::URI, $this->queryString());
+        if ($response) {
+            $this->html = $response;
             $this->parseResponse();
         }
 

--- a/src/Drivers/IsraelDriver.php
+++ b/src/Drivers/IsraelDriver.php
@@ -5,7 +5,6 @@ namespace FlexMindSoftware\CurrencyRate\Drivers;
 use FlexMindSoftware\CurrencyRate\Contracts\CurrencyInterface;
 use FlexMindSoftware\CurrencyRate\Models\Currency;
 use FlexMindSoftware\CurrencyRate\Models\RateTrait;
-use Illuminate\Support\Facades\Http;
 
 class IsraelDriver extends BaseDriver implements CurrencyInterface
 {
@@ -41,15 +40,15 @@ class IsraelDriver extends BaseDriver implements CurrencyInterface
      */
     public function grabExchangeRates(): self
     {
-        $respond = Http::get('https://www.boi.org.il/currency.xml');
-        if ($respond->ok()) {
-            $this->xml = $respond->body();
+        $respond = $this->fetch('https://www.boi.org.il/currency.xml');
+        if ($respond) {
+            $this->xml = $respond;
             $this->makeCountryMap();
         }
 
-        $respond = Http::get(static::URI, $this->queryString());
-        if ($respond->ok()) {
-            $this->html = $respond->body();
+        $respond = $this->fetch(static::URI, $this->queryString());
+        if ($respond) {
+            $this->html = $respond;
             $this->parseResponse();
         }
 
@@ -58,7 +57,7 @@ class IsraelDriver extends BaseDriver implements CurrencyInterface
 
     private function makeCountryMap()
     {
-        $xmlElement = simplexml_load_string($this->xml, "SimpleXMLElement", LIBXML_NOCDATA);
+        $xmlElement = $this->parseXml($this->xml);
         $json = json_decode(json_encode($xmlElement), true);
 
         $this->countryList = [];

--- a/src/Drivers/MoldaviaDriver.php
+++ b/src/Drivers/MoldaviaDriver.php
@@ -7,7 +7,6 @@ use Exception;
 use FlexMindSoftware\CurrencyRate\Contracts\CurrencyInterface;
 use FlexMindSoftware\CurrencyRate\Models\Currency;
 use FlexMindSoftware\CurrencyRate\Models\RateTrait;
-use Illuminate\Support\Facades\Http;
 use SimpleXMLElement;
 
 class MoldaviaDriver extends BaseDriver implements CurrencyInterface
@@ -38,9 +37,9 @@ class MoldaviaDriver extends BaseDriver implements CurrencyInterface
      */
     public function grabExchangeRates(): self
     {
-        $respond = Http::get(static::URI, $this->queryString());
-        if ($respond->ok()) {
-            $this->xml = $respond->body();
+        $respond = $this->fetch(static::URI, $this->queryString());
+        if ($respond) {
+            $this->xml = $respond;
             $this->parseResponse();
         }
 
@@ -62,7 +61,7 @@ class MoldaviaDriver extends BaseDriver implements CurrencyInterface
      */
     private function parseResponse()
     {
-        $xml = new SimpleXMLElement($this->xml);
+        $xml = $this->parseXml($this->xml);
         $date = Datetime::createFromFormat('d.m.Y', $xml->attributes()->Date)->format('d.m.Y');
 
         $this->data = [];

--- a/src/Drivers/MoldaviaDriver.php
+++ b/src/Drivers/MoldaviaDriver.php
@@ -7,7 +7,6 @@ use Exception;
 use FlexMindSoftware\CurrencyRate\Contracts\CurrencyInterface;
 use FlexMindSoftware\CurrencyRate\Models\Currency;
 use FlexMindSoftware\CurrencyRate\Models\RateTrait;
-use SimpleXMLElement;
 
 class MoldaviaDriver extends BaseDriver implements CurrencyInterface
 {

--- a/src/Drivers/NorwayDriver.php
+++ b/src/Drivers/NorwayDriver.php
@@ -6,7 +6,6 @@ use DateInterval;
 use FlexMindSoftware\CurrencyRate\Contracts\CurrencyInterface;
 use FlexMindSoftware\CurrencyRate\Models\Currency;
 use FlexMindSoftware\CurrencyRate\Models\RateTrait;
-use Illuminate\Support\Facades\Http;
 
 class NorwayDriver extends BaseDriver implements CurrencyInterface
 {
@@ -34,9 +33,9 @@ class NorwayDriver extends BaseDriver implements CurrencyInterface
      */
     public function grabExchangeRates(): self
     {
-        $response = Http::get(static::URI, $this->getQueryString());
-        if ($response->ok()) {
-            $this->json = $response->json();
+        $response = $this->fetch(static::URI, $this->getQueryString());
+        if ($response) {
+            $this->json = json_decode($response, true);
             $this->parseBody();
         }
 

--- a/src/Drivers/PolandDriver.php
+++ b/src/Drivers/PolandDriver.php
@@ -6,8 +6,6 @@ use Exception;
 use FlexMindSoftware\CurrencyRate\Contracts\CurrencyInterface;
 use FlexMindSoftware\CurrencyRate\Models\Currency;
 use FlexMindSoftware\CurrencyRate\Models\RateTrait;
-use Illuminate\Support\Facades\Http;
-use SimpleXMLElement;
 
 class PolandDriver extends BaseDriver implements CurrencyInterface
 {
@@ -32,9 +30,8 @@ class PolandDriver extends BaseDriver implements CurrencyInterface
      */
     public function grabExchangeRates(): self
     {
-        $response = Http::get(static::URI . 'dir.txt');
-        if ($response->ok()) {
-            $exchangeRateList = $response->body();
+        $exchangeRateList = $this->fetch(static::URI . 'dir.txt');
+        if ($exchangeRateList) {
 
             $timestamp = $this->date->getTimestamp();
             if (intval(date('Hi', $timestamp)) < 1215) {
@@ -48,9 +45,8 @@ class PolandDriver extends BaseDriver implements CurrencyInterface
                 ! blank($matches[0])
             ) {
                 foreach ($matches[0] as $nbpNo) {
-                    $response = Http::get(static::URI . $nbpNo . '.xml');
-                    if ($response->ok()) {
-                        $xml = $response->body();
+                    $xml = $this->fetch(static::URI . $nbpNo . '.xml');
+                    if ($xml) {
                         $this->parseData($xml);
                     }
                 }
@@ -67,7 +63,7 @@ class PolandDriver extends BaseDriver implements CurrencyInterface
      */
     private function parseData(string $xml)
     {
-        $currencies = new SimpleXMLElement($xml);
+        $currencies = $this->parseXml($xml);
         $currencies = json_decode(json_encode($currencies), true);
 
         $param = [];

--- a/src/Drivers/RomaniaDriver.php
+++ b/src/Drivers/RomaniaDriver.php
@@ -5,7 +5,6 @@ namespace FlexMindSoftware\CurrencyRate\Drivers;
 use FlexMindSoftware\CurrencyRate\Contracts\CurrencyInterface;
 use FlexMindSoftware\CurrencyRate\Models\Currency;
 use FlexMindSoftware\CurrencyRate\Models\RateTrait;
-use Illuminate\Support\Facades\Http;
 use SimpleXMLElement;
 
 /**
@@ -43,10 +42,9 @@ class RomaniaDriver extends BaseDriver implements CurrencyInterface
      */
     public function grabExchangeRates(): self
     {
-        $respond = Http::get($this->sourceUrl());
-        if ($respond->ok()) {
-            $xml = $respond->body();
-            $this->xml = simplexml_load_string($xml);
+        $respond = $this->fetch($this->sourceUrl());
+        if ($respond) {
+            $this->xml = $this->parseXml($respond);
             $this->parseDate();
             $this->findByDate("");
         }

--- a/src/Drivers/RussiaDriver.php
+++ b/src/Drivers/RussiaDriver.php
@@ -6,7 +6,6 @@ use DateTime;
 use FlexMindSoftware\CurrencyRate\Contracts\CurrencyInterface;
 use FlexMindSoftware\CurrencyRate\Models\Currency;
 use FlexMindSoftware\CurrencyRate\Models\RateTrait;
-use Illuminate\Support\Facades\Http;
 
 class RussiaDriver extends BaseDriver implements CurrencyInterface
 {
@@ -35,9 +34,9 @@ class RussiaDriver extends BaseDriver implements CurrencyInterface
      */
     public function grabExchangeRates(): self
     {
-        $respond = Http::get(static::URI, $this->queryString());
-        if ($respond->ok()) {
-            $this->html = $respond->body();
+        $respond = $this->fetch(static::URI, $this->queryString());
+        if ($respond) {
+            $this->html = $respond;
             $this->parseResponse();
         }
 

--- a/src/Drivers/SwedenDriver.php
+++ b/src/Drivers/SwedenDriver.php
@@ -6,7 +6,6 @@ use DateInterval;
 use FlexMindSoftware\CurrencyRate\Contracts\CurrencyInterface;
 use FlexMindSoftware\CurrencyRate\Models\Currency;
 use FlexMindSoftware\CurrencyRate\Models\RateTrait;
-use Illuminate\Support\Facades\Http;
 
 /**
  *
@@ -39,9 +38,9 @@ class SwedenDriver extends BaseDriver implements CurrencyInterface
      */
     public function grabExchangeRates(): self
     {
-        $respond = Http::get(static::URI, $this->getQueryString());
-        if ($respond->ok()) {
-            $this->response = $respond->body();
+        $respond = $this->fetch(static::URI, $this->getQueryString());
+        if ($respond) {
+            $this->response = $respond;
             $this->parseResponse();
         }
 
@@ -116,10 +115,7 @@ class SwedenDriver extends BaseDriver implements CurrencyInterface
      */
     private function parseResponse()
     {
-        $rows = explode("\r\n", $this->response);
-        $rows = array_map(function ($line) {
-            return explode(';', $line);
-        }, $rows);
+        $rows = $this->parseCsv($this->response, ';');
 
         $rows = array_filter($rows, function ($line) {
             return count($line) === 4;

--- a/src/Drivers/SwitzerlandDriver.php
+++ b/src/Drivers/SwitzerlandDriver.php
@@ -6,7 +6,6 @@ use DateTime;
 use FlexMindSoftware\CurrencyRate\Contracts\CurrencyInterface;
 use FlexMindSoftware\CurrencyRate\Models\Currency;
 use FlexMindSoftware\CurrencyRate\Models\RateTrait;
-use Illuminate\Support\Facades\Http;
 
 class SwitzerlandDriver extends BaseDriver implements CurrencyInterface
 {
@@ -35,9 +34,9 @@ class SwitzerlandDriver extends BaseDriver implements CurrencyInterface
      */
     public function grabExchangeRates(): self
     {
-        $respond = Http::get(static::URI);
-        if ($respond->ok()) {
-            $this->xml = $respond->body();
+        $respond = $this->fetch(static::URI);
+        if ($respond) {
+            $this->xml = $respond;
             $this->parseResponse();
         }
 
@@ -46,7 +45,7 @@ class SwitzerlandDriver extends BaseDriver implements CurrencyInterface
 
     private function parseResponse()
     {
-        $simpleXMLElement = simplexml_load_string($this->xml, "SimpleXMLElement", LIBXML_NOCDATA, "", true);
+        $simpleXMLElement = $this->parseXml($this->xml, LIBXML_NOCDATA, '', true);
 
         foreach ($simpleXMLElement->channel->item as $line) {
             preg_match(

--- a/src/Drivers/TurkeyDriver.php
+++ b/src/Drivers/TurkeyDriver.php
@@ -7,7 +7,6 @@ use DateTime;
 use FlexMindSoftware\CurrencyRate\Contracts\CurrencyInterface;
 use FlexMindSoftware\CurrencyRate\Models\Currency;
 use FlexMindSoftware\CurrencyRate\Models\RateTrait;
-use Illuminate\Support\Facades\Http;
 
 class TurkeyDriver extends BaseDriver implements CurrencyInterface
 {
@@ -38,12 +37,12 @@ class TurkeyDriver extends BaseDriver implements CurrencyInterface
     public function grabExchangeRates(): self
     {
         do {
-            $respond = Http::get(static::URI . $this->queryString());
-            if ($respond->ok()) {
-                $this->xml = $respond->body();
+            $respond = $this->fetch(static::URI . $this->queryString());
+            if ($respond) {
+                $this->xml = $respond;
             }
             $this->date = $this->date->sub(DateInterval::createFromDateString('1 day'));
-        } while (! $respond->ok());
+        } while (! $respond);
 
         $this->parseResponse();
 
@@ -60,7 +59,7 @@ class TurkeyDriver extends BaseDriver implements CurrencyInterface
 
     private function parseResponse()
     {
-        $simpleXMLElement = simplexml_load_string($this->xml);
+        $simpleXMLElement = $this->parseXml($this->xml);
         $no = $simpleXMLElement->attributes()->Bulten_No;
         $date = DateTime::createFromFormat('m/d/Y', (string)$simpleXMLElement->attributes()->Date)->format('Y-m-d');
 

--- a/src/Drivers/UkraineDriver.php
+++ b/src/Drivers/UkraineDriver.php
@@ -5,7 +5,6 @@ namespace FlexMindSoftware\CurrencyRate\Drivers;
 use FlexMindSoftware\CurrencyRate\Contracts\CurrencyInterface;
 use FlexMindSoftware\CurrencyRate\Models\Currency;
 use FlexMindSoftware\CurrencyRate\Models\RateTrait;
-use Illuminate\Support\Facades\Http;
 
 class UkraineDriver extends BaseDriver implements CurrencyInterface
 {
@@ -34,9 +33,9 @@ class UkraineDriver extends BaseDriver implements CurrencyInterface
      */
     public function grabExchangeRates(): self
     {
-        $respond = Http::get(static::URI, $this->queryString());
-        if ($respond->ok()) {
-            $this->html = $respond->body();
+        $respond = $this->fetch(static::URI, $this->queryString());
+        if ($respond) {
+            $this->html = $respond;
             $this->parseResponse();
         }
 

--- a/tests/HttpFetcherTest.php
+++ b/tests/HttpFetcherTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace FlexMindSoftware\CurrencyRate\Tests;
+
+use FlexMindSoftware\CurrencyRate\Drivers\HttpFetcher;
+use Illuminate\Support\Facades\Http;
+
+class HttpFetcherTest extends TestCase
+{
+    /** @test */
+    public function fetch_returns_body_on_success()
+    {
+        Http::fake([
+            'example.com/*' => Http::response('content', 200),
+        ]);
+
+        $fetcher = new class {
+            use HttpFetcher;
+        };
+
+        $this->assertEquals('content', $fetcher->fetch('https://example.com/test'));
+    }
+
+    /** @test */
+    public function parse_xml_returns_simplexml_element()
+    {
+        $fetcher = new class {
+            use HttpFetcher;
+        };
+
+        $xml = '<root><item>value</item></root>';
+        $parsed = $fetcher->parseXml($xml);
+
+        $this->assertEquals('value', (string)$parsed->item);
+    }
+
+    /** @test */
+    public function parse_csv_splits_rows()
+    {
+        $fetcher = new class {
+            use HttpFetcher;
+        };
+
+        $csv = "a;b\n1;2";
+        $parsed = $fetcher->parseCsv($csv, ';');
+
+        $this->assertEquals(['a', 'b'], $parsed[0]);
+        $this->assertEquals(['1', '2'], $parsed[1]);
+    }
+}
+

--- a/tests/HttpFetcherTest.php
+++ b/tests/HttpFetcherTest.php
@@ -14,7 +14,7 @@ class HttpFetcherTest extends TestCase
             'example.com/*' => Http::response('content', 200),
         ]);
 
-        $fetcher = new class {
+        $fetcher = new class () {
             use HttpFetcher;
         };
 
@@ -24,7 +24,7 @@ class HttpFetcherTest extends TestCase
     /** @test */
     public function parse_xml_returns_simplexml_element()
     {
-        $fetcher = new class {
+        $fetcher = new class () {
             use HttpFetcher;
         };
 
@@ -37,7 +37,7 @@ class HttpFetcherTest extends TestCase
     /** @test */
     public function parse_csv_splits_rows()
     {
-        $fetcher = new class {
+        $fetcher = new class () {
             use HttpFetcher;
         };
 
@@ -48,4 +48,3 @@ class HttpFetcherTest extends TestCase
         $this->assertEquals(['1', '2'], $parsed[1]);
     }
 }
-


### PR DESCRIPTION
## Summary
- add reusable `HttpFetcher` trait with helpers to fetch URLs and parse XML/CSV
- refactor drivers to leverage new trait and remove duplicated HTTP logic
- cover trait with unit tests using `Http::fake`

## Testing
- `composer install` *(fails: Root composer.json requires php ^7.4 but current php version (8.2.29) does not satisfy)*

------
https://chatgpt.com/codex/tasks/task_e_68a551175dd08333b46d4dc27b424304