### PR TITLE
Dispatch CurrencyRateSaved event

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,19 @@ Options:
   --driver[=DRIVER]  Driver to download rate [default: "all"]
 ```
 
+## Events
+
+The `CurrencyRate::saveIn` method dispatches a `CurrencyRateSaved` event once rates are persisted. Consumers may listen for this event to trigger downstream actions:
+
+```php
+use FlexMindSoftware\CurrencyRate\Events\CurrencyRateSaved;
+use Illuminate\Support\Facades\Event;
+
+Event::listen(CurrencyRateSaved::class, function (CurrencyRateSaved $event) {
+    // $event->rates contains the saved records
+});
+```
+
 ## Testing
 
 ```bash

--- a/src/Events/CurrencyRateSaved.php
+++ b/src/Events/CurrencyRateSaved.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace FlexMindSoftware\CurrencyRate\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class CurrencyRateSaved
+{
+    use Dispatchable, SerializesModels;
+
+    public array $rates;
+
+    public function __construct(array $rates)
+    {
+        $this->rates = $rates;
+    }
+}

--- a/src/Models/CurrencyRate.php
+++ b/src/Models/CurrencyRate.php
@@ -3,6 +3,7 @@
 namespace FlexMindSoftware\CurrencyRate\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use FlexMindSoftware\CurrencyRate\Events\CurrencyRateSaved;
 
 class CurrencyRate extends Model
 {
@@ -50,6 +51,8 @@ class CurrencyRate extends Model
             foreach ($chunks as $chunk) {
                 static::on($connection)
                     ->upsert($chunk, $columns, ['rate', 'no', 'multiplier']);
+
+                event(new CurrencyRateSaved($chunk));
             }
         }
     }

--- a/tests/CurrencyRateSaveInTest.php
+++ b/tests/CurrencyRateSaveInTest.php
@@ -3,6 +3,8 @@
 namespace FlexMindSoftware\CurrencyRate\Tests;
 
 use FlexMindSoftware\CurrencyRate\Models\CurrencyRate;
+use FlexMindSoftware\CurrencyRate\Events\CurrencyRateSaved;
+use Illuminate\Support\Facades\Event;
 
 class CurrencyRateSaveInTest extends TestCase
 {
@@ -15,8 +17,10 @@ class CurrencyRateSaveInTest extends TestCase
     }
 
     /** @test */
-    public function it_saves_records_to_database()
+    public function it_saves_records_to_database_and_fires_event()
     {
+        Event::fake();
+
         $data = [
             [
                 'driver' => 'test',
@@ -40,5 +44,9 @@ class CurrencyRateSaveInTest extends TestCase
 
         $this->assertDatabaseHas('currency_rates', ['code' => 'USD']);
         $this->assertDatabaseHas('currency_rates', ['code' => 'PLN']);
+
+        Event::assertDispatched(CurrencyRateSaved::class, function ($event) use ($data) {
+            return $event->rates === $data;
+        });
     }
 }


### PR DESCRIPTION
## Summary
- dispatch CurrencyRateSaved event after persisting rates
- document CurrencyRateSaved event usage
- test event dispatch from CurrencyRate::saveIn

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68a5599c526c8333a699097736b62c89