### PR TITLE
Use SplFileObject for robust CSV parsing

### DIFF
--- a/src/Drivers/HttpFetcher.php
+++ b/src/Drivers/HttpFetcher.php
@@ -25,11 +25,20 @@ trait HttpFetcher
 
     protected function parseCsv(string $csv, string $delimiter = ';'): array
     {
-        $lines = preg_split('/\r\n|\n|\r/', trim($csv));
+        $file = new \SplFileObject('php://temp', 'r+');
+        $file->fwrite($csv);
+        $file->rewind();
+        $file->setCsvControl($delimiter);
+        $file->setFlags(\SplFileObject::READ_CSV | \SplFileObject::SKIP_EMPTY);
 
-        return array_map(
-            fn ($line) => str_getcsv($line, $delimiter),
-            array_filter($lines)
-        );
+        $rows = [];
+        foreach ($file as $row) {
+            if ($row === [null] || $row === false) {
+                continue;
+            }
+            $rows[] = $row;
+        }
+
+        return $rows;
     }
 }

--- a/tests/HttpFetcherTest.php
+++ b/tests/HttpFetcherTest.php
@@ -62,4 +62,20 @@ class HttpFetcherTest extends TestCase
         $this->assertEquals(['a', 'b'], $parsed[0]);
         $this->assertEquals(['1', '2'], $parsed[1]);
     }
+
+    /** @test */
+    public function parse_csv_handles_quoted_delimiters_and_escapes()
+    {
+        $fetcher = $this->fetcher();
+
+        $csv = <<<'CSV'
+"a;b";"c""d"
+"e;f";"g""h"
+CSV;
+
+        $parsed = $fetcher->callParseCsv($csv, ';');
+
+        $this->assertEquals(['a;b', 'c"d'], $parsed[0]);
+        $this->assertEquals(['e;f', 'g"h'], $parsed[1]);
+    }
 }


### PR DESCRIPTION
## Summary
- replace regex-based CSV parsing with SplFileObject to handle quoted delimiters and escapes
- test CSV parser with embedded delimiters and escaped quotes

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68a559a5f49083338ecb3eda93c6fff3