### PR TITLE
refactor: traverse XML directly in drivers

### DIFF
--- a/src/Drivers/AustraliaDriver.php
+++ b/src/Drivers/AustraliaDriver.php
@@ -42,10 +42,9 @@ class AustraliaDriver extends BaseDriver implements CurrencyInterface
         return $this;
     }
 
-    private function parseResponse()
+    private function parseResponse(): void
     {
         $xml = $this->parseXml($this->xml);
-        $json = json_decode(json_encode($xml), true);
 
         $currencyList = [];
         foreach ($xml->item as $item) {

--- a/src/Drivers/AzerbaijanDriver.php
+++ b/src/Drivers/AzerbaijanDriver.php
@@ -43,23 +43,20 @@ class AzerbaijanDriver extends BaseDriver implements CurrencyInterface
         return $this;
     }
 
-    private function parseResponse()
+    private function parseResponse(): void
     {
         $xmlElement = $this->parseXml($this->xml);
-        $json = json_decode(json_encode($xmlElement), true);
-        $date = DateTime::createFromFormat('d.m.Y', $json['@attributes']['Date'])->format('Y-m-d');
+        $date = DateTime::createFromFormat('d.m.Y', (string) $xmlElement['Date'])->format('Y-m-d');
 
-        foreach ($json['Valute'] ?? [] as $item) {
-            $line = [
+        foreach ($xmlElement->Valute as $item) {
+            $this->data[] = [
                 'no' => null,
-                'code' => $item['CharCode'],
+                'code' => (string) $item->CharCode,
                 'date' => $date,
                 'driver' => static::DRIVER_NAME,
-                'multiplier' => floatval($item['Nominal']),
-                'rate' => $this->stringToFloat($item['Value']),
+                'multiplier' => (float) $item->Nominal,
+                'rate' => $this->stringToFloat((string) $item->Value),
             ];
-
-            $this->data[] = $line;
         }
     }
 

--- a/src/Drivers/EuropeanCentralBankDriver.php
+++ b/src/Drivers/EuropeanCentralBankDriver.php
@@ -43,19 +43,22 @@ class EuropeanCentralBankDriver extends BaseDriver implements CurrencyInterface
     }
 
     /**
-     * @param SimpleXMLElement $jsonData
+     * Traverse SimpleXMLElement for date and currency data.
      */
-    private function parseDate(SimpleXMLElement $jsonData)
+    private function parseDate(SimpleXMLElement $cubes): void
     {
-        $jsonData = json_decode(json_encode($jsonData), true);
-        foreach ($jsonData['Cube'] ?? [] as $children) {
-            foreach ($children as $node) {
-                $this->data[$node['currency']]['date'] = $jsonData['@attributes']['time'];
-                $this->data[$node['currency']]['rate'] = floatval($node['rate']);
-                $this->data[$node['currency']]['multiplier'] = 1;
-                $this->data[$node['currency']]['no'] = null;
-                $this->data[$node['currency']]['driver'] = static::DRIVER_NAME;
-                $this->data[$node['currency']]['code'] = $node['currency'];
+        foreach ($cubes as $cube) {
+            $date = (string) $cube['time'];
+
+            foreach ($cube->Cube as $node) {
+                $currency = (string) $node['currency'];
+
+                $this->data[$currency]['date'] = $date;
+                $this->data[$currency]['rate'] = (float) $node['rate'];
+                $this->data[$currency]['multiplier'] = 1;
+                $this->data[$currency]['no'] = null;
+                $this->data[$currency]['driver'] = static::DRIVER_NAME;
+                $this->data[$currency]['code'] = $currency;
             }
         }
     }

--- a/src/Drivers/IsraelDriver.php
+++ b/src/Drivers/IsraelDriver.php
@@ -55,14 +55,15 @@ class IsraelDriver extends BaseDriver implements CurrencyInterface
         return $this;
     }
 
-    private function makeCountryMap()
+    private function makeCountryMap(): void
     {
         $xmlElement = $this->parseXml($this->xml);
-        $json = json_decode(json_encode($xmlElement), true);
 
         $this->countryList = [];
-        foreach ($json['CURRENCY'] ?? [] as $item) {
-            $this->countryList[$item['COUNTRY']] = $item['CURRENCYCODE'];
+        foreach ($xmlElement->CURRENCY as $item) {
+            $country = (string) $item->COUNTRY;
+            $code = (string) $item->CURRENCYCODE;
+            $this->countryList[$country] = $code;
         }
     }
 

--- a/src/Drivers/PolandDriver.php
+++ b/src/Drivers/PolandDriver.php
@@ -61,24 +61,21 @@ class PolandDriver extends BaseDriver implements CurrencyInterface
      *
      * @throws Exception
      */
-    private function parseData(string $xml)
+    private function parseData(string $xml): void
     {
         $currencies = $this->parseXml($xml);
-        $currencies = json_decode(json_encode($currencies), true);
 
-        $param = [];
-        $param['no'] = $currencies['numer_tabeli'];
-        $param['driver'] = static::DRIVER_NAME;
-        $param['date'] = $currencies['data_publikacji'];
+        $param = [
+            'no' => (string) $currencies->numer_tabeli,
+            'driver' => static::DRIVER_NAME,
+            'date' => (string) $currencies->data_publikacji,
+        ];
 
-        foreach ($currencies['pozycja'] as $position) {
-            if (isset($position['kod_waluty']) &&
-                isset($position['kurs_sredni']) &&
-                isset($position['przelicznik'])
-            ) {
-                $param['code'] = strtoupper($position['kod_waluty']);
-                $param['rate'] = $this->stringToFloat($position['kurs_sredni']);
-                $param['multiplier'] = $this->stringToFloat($position['przelicznik']);
+        foreach ($currencies->pozycja as $position) {
+            if (isset($position->kod_waluty, $position->kurs_sredni, $position->przelicznik)) {
+                $param['code'] = strtoupper((string) $position->kod_waluty);
+                $param['rate'] = $this->stringToFloat((string) $position->kurs_sredni);
+                $param['multiplier'] = $this->stringToFloat((string) $position->przelicznik);
                 $this->data[] = $param;
             }
         }


### PR DESCRIPTION
## Summary
- refactor drivers to traverse SimpleXMLElement directly instead of using json_encode/json_decode
- streamline Australian driver XML parsing by removing unnecessary JSON conversion

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68a559ae4a6483339acce46a656c6516