### PR TITLE
Add driver metadata interface for consistent driver metadata

### DIFF
--- a/src/Contracts/DriverMetadata.php
+++ b/src/Contracts/DriverMetadata.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace FlexMindSoftware\CurrencyRate\Contracts;
+
+interface DriverMetadata
+{
+    /**
+     * Retrieve driver unique name.
+     */
+    public function driverName(): string;
+
+    /**
+     * Retrieve base URI used by driver.
+     */
+    public function uri(): string;
+}
+

--- a/src/Contracts/DriverMetadata.php
+++ b/src/Contracts/DriverMetadata.php
@@ -14,4 +14,3 @@ interface DriverMetadata
      */
     public function uri(): string;
 }
-

--- a/src/Drivers/BaseDriver.php
+++ b/src/Drivers/BaseDriver.php
@@ -5,11 +5,22 @@ namespace FlexMindSoftware\CurrencyRate\Drivers;
 use DateTime;
 use DOMDocument;
 use DOMXPath;
+use FlexMindSoftware\CurrencyRate\Contracts\DriverMetadata;
 use FlexMindSoftware\CurrencyRate\Models\CurrencyRate;
 
-abstract class BaseDriver
+abstract class BaseDriver implements DriverMetadata
 {
     use HttpFetcher;
+
+    /**
+     * @const string
+     */
+    public const DRIVER_NAME = '';
+
+    /**
+     * @const string
+     */
+    public const URI = '';
     /**
      * @var DateTime
      */
@@ -74,6 +85,22 @@ abstract class BaseDriver
     public function retrieveData(): array
     {
         return $this->data;
+    }
+
+    /**
+     * Return driver unique name.
+     */
+    public function driverName(): string
+    {
+        return static::DRIVER_NAME;
+    }
+
+    /**
+     * Return driver base URI.
+     */
+    public function uri(): string
+    {
+        return static::URI;
     }
 
     protected function saveInDatabase()

--- a/tests/DriverMetadataTest.php
+++ b/tests/DriverMetadataTest.php
@@ -25,4 +25,3 @@ class DriverMetadataTest extends TestCase
         $this->assertSame(FakeDriver::URI, $driver->uri());
     }
 }
-

--- a/tests/DriverMetadataTest.php
+++ b/tests/DriverMetadataTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace FlexMindSoftware\CurrencyRate\Tests;
+
+use FlexMindSoftware\CurrencyRate\Contracts\DriverMetadata;
+use FlexMindSoftware\CurrencyRate\Tests\Stubs\FakeDriver;
+
+class DriverMetadataTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+        file_put_contents(__DIR__.'/../database/database.sqlite', '');
+        $migration = include __DIR__.'/../database/migrations/create_currency_rate_table.php.stub';
+        $migration->up();
+    }
+
+    /** @test */
+    public function it_exposes_driver_name_and_uri()
+    {
+        $driver = new FakeDriver();
+
+        $this->assertInstanceOf(DriverMetadata::class, $driver);
+        $this->assertSame(FakeDriver::DRIVER_NAME, $driver->driverName());
+        $this->assertSame(FakeDriver::URI, $driver->uri());
+    }
+}
+

--- a/tests/Stubs/FakeDriver.php
+++ b/tests/Stubs/FakeDriver.php
@@ -12,11 +12,12 @@ class FakeDriver extends BaseDriver implements CurrencyInterface
     use RateTrait;
 
     public const DRIVER_NAME = 'fake';
+    public const URI = 'https://example.com/rates';
     public CurrencyCode $currency = CurrencyCode::EUR;
 
     public function grabExchangeRates(): self
     {
-        $this->fetch('https://example.com/rates');
+        $this->fetch(static::URI);
 
         $this->data[] = [
             'driver' => self::DRIVER_NAME,


### PR DESCRIPTION
## Summary
- add `DriverMetadata` contract exposing `driverName` and `uri`
- implement metadata accessors in `BaseDriver`
- define URI on test `FakeDriver` and add unit test

## Testing
- `composer test`
- `composer psalm` *(fails: Class, interface or enum named CurrencyRate does not exist; 170 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a559b49a508333951c9b56b11dde79