### PR TITLE
Add configuration validation to service provider

### DIFF
--- a/src/CurrencyRateServiceProvider.php
+++ b/src/CurrencyRateServiceProvider.php
@@ -5,6 +5,7 @@ namespace FlexMindSoftware\CurrencyRate;
 use FlexMindSoftware\CurrencyRate\Commands\CurrencyRateCommand;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
+use InvalidArgumentException;
 
 class CurrencyRateServiceProvider extends PackageServiceProvider
 {
@@ -23,8 +24,23 @@ class CurrencyRateServiceProvider extends PackageServiceProvider
 
     public function packageRegistered()
     {
+        $this->validateConfig();
+
         $this->app->singleton('currency-rate', function ($app) {
             return new CurrencyRateManager($app);
         });
+    }
+
+    protected function validateConfig(): void
+    {
+        $required = ['driver', 'table-name', 'drivers'];
+
+        foreach ($required as $key) {
+            if (! config()->has("currency-rate.$key") || empty(config("currency-rate.$key"))) {
+                throw new InvalidArgumentException(
+                    "currency-rate configuration missing required key [$key]."
+                );
+            }
+        }
     }
 }

--- a/src/CurrencyRateServiceProvider.php
+++ b/src/CurrencyRateServiceProvider.php
@@ -3,9 +3,9 @@
 namespace FlexMindSoftware\CurrencyRate;
 
 use FlexMindSoftware\CurrencyRate\Commands\CurrencyRateCommand;
+use InvalidArgumentException;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
-use InvalidArgumentException;
 
 class CurrencyRateServiceProvider extends PackageServiceProvider
 {

--- a/tests/ConfigValidatorTest.php
+++ b/tests/ConfigValidatorTest.php
@@ -38,4 +38,3 @@ class ConfigValidatorTest extends TestCase
         $this->assertTrue($this->app->bound('currency-rate'));
     }
 }
-

--- a/tests/ConfigValidatorTest.php
+++ b/tests/ConfigValidatorTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace FlexMindSoftware\CurrencyRate\Tests;
+
+use FlexMindSoftware\CurrencyRate\CurrencyRateServiceProvider;
+
+class ConfigValidatorTest extends TestCase
+{
+    protected function getPackageProviders($app)
+    {
+        return [];
+    }
+
+    /** @test */
+    public function it_throws_exception_when_required_config_missing()
+    {
+        $this->app['config']->set('currency-rate', []);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('currency-rate configuration missing required key [driver].');
+
+        $provider = new CurrencyRateServiceProvider($this->app);
+        $provider->packageRegistered();
+    }
+
+    /** @test */
+    public function it_passes_when_required_config_present()
+    {
+        $this->app['config']->set('currency-rate', [
+            'driver' => 'european-central-bank',
+            'drivers' => ['european-central-bank'],
+            'table-name' => 'currency_rates',
+        ]);
+
+        $provider = new CurrencyRateServiceProvider($this->app);
+        $provider->packageRegistered();
+
+        $this->assertTrue($this->app->bound('currency-rate'));
+    }
+}
+


### PR DESCRIPTION
## Summary
- validate required `currency-rate` config keys during package registration
- test configuration validation logic

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68a559f320ac8333bb9739bc8db01358