### PR TITLE
Add tests for multi-driver command behavior

### DIFF
--- a/tests/MultipleDriversCommandTest.php
+++ b/tests/MultipleDriversCommandTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace FlexMindSoftware\CurrencyRate\Tests;
+
+use FlexMindSoftware\CurrencyRate\CurrencyRateFacade as CurrencyRate;
+use FlexMindSoftware\CurrencyRate\Jobs\QueueDownload;
+use FlexMindSoftware\CurrencyRate\Tests\Stubs\FakeDriver;
+use FlexMindSoftware\CurrencyRate\Tests\Stubs\SecondFakeDriver;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Queue;
+
+class MultipleDriversCommandTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+        file_put_contents(__DIR__.'/../database/database.sqlite', '');
+        $migration = include __DIR__.'/../database/migrations/create_currency_rate_table.php.stub';
+        $migration->up();
+        CurrencyRate::extend(FakeDriver::DRIVER_NAME, fn () => new FakeDriver());
+        CurrencyRate::extend(SecondFakeDriver::DRIVER_NAME, fn () => new SecondFakeDriver());
+        config(['currency-rate.drivers' => [FakeDriver::DRIVER_NAME, SecondFakeDriver::DRIVER_NAME]]);
+    }
+
+    /** @test */
+    public function it_dispatches_jobs_for_all_drivers()
+    {
+        Queue::fake();
+
+        $this->artisan('flexmind:currency-rate', [
+            'date' => '2023-10-01',
+            '--driver' => 'all',
+            '--queue' => 'default',
+            '--connection' => 'testing',
+        ]);
+
+        Queue::assertPushed(QueueDownload::class, 2);
+        Queue::assertPushed(QueueDownload::class, function ($job) {
+            return str_contains($job->uniqueId(), FakeDriver::DRIVER_NAME);
+        });
+        Queue::assertPushed(QueueDownload::class, function ($job) {
+            return str_contains($job->uniqueId(), SecondFakeDriver::DRIVER_NAME);
+        });
+    }
+
+    /** @test */
+    public function it_saves_rates_from_all_drivers()
+    {
+        Http::fake([
+            'example.com/*' => Http::response('ok', 200),
+        ]);
+
+        $this->artisan('flexmind:currency-rate', [
+            'date' => '2023-10-01',
+            '--driver' => 'all',
+            '--queue' => 'none',
+            '--connection' => 'testing',
+        ])->assertExitCode(0);
+
+        $this->assertDatabaseHas('currency_rates', ['code' => 'USD']);
+        $this->assertDatabaseHas('currency_rates', ['code' => 'GBP']);
+    }
+}

--- a/tests/Stubs/SecondFakeDriver.php
+++ b/tests/Stubs/SecondFakeDriver.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace FlexMindSoftware\CurrencyRate\Tests\Stubs;
+
+use FlexMindSoftware\CurrencyRate\Contracts\CurrencyInterface;
+use FlexMindSoftware\CurrencyRate\Drivers\BaseDriver;
+use FlexMindSoftware\CurrencyRate\Enums\CurrencyCode;
+use FlexMindSoftware\CurrencyRate\Models\RateTrait;
+
+class SecondFakeDriver extends BaseDriver implements CurrencyInterface
+{
+    use RateTrait;
+
+    public const DRIVER_NAME = 'fake2';
+    public const URI = 'https://example.com/other';
+    public CurrencyCode $currency = CurrencyCode::EUR;
+
+    public function grabExchangeRates(): self
+    {
+        $this->fetch(static::URI);
+
+        $this->data[] = [
+            'driver' => self::DRIVER_NAME,
+            'code' => 'GBP',
+            'date' => '2023-10-01',
+            'rate' => 1.2,
+            'multiplier' => 1,
+            'no' => null,
+        ];
+
+        return $this;
+    }
+
+    public function fullName(): string
+    {
+        return 'Second Fake Driver';
+    }
+
+    public function homeUrl(): string
+    {
+        return 'https://example.com';
+    }
+
+    public function infoAboutFrequency(): string
+    {
+        return '';
+    }
+}


### PR DESCRIPTION
## Summary
- add `SecondFakeDriver` stub for testing additional driver
- verify `flexmind:currency-rate` command handles multiple drivers with queue dispatch and database persistence

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68a55c9d85a883339cb57263358c6636