### PR TITLE
Add HTTP retry with exponential backoff

### DIFF
--- a/config/currency-rate.php
+++ b/config/currency-rate.php
@@ -36,5 +36,10 @@ return [
         'turkey',
         'ukraine',
     ],
-    'table-name' => env('FLEXMIND_CURRENCY_RATE_TABLENAME', 'currency_rates')
+    'table-name' => env('FLEXMIND_CURRENCY_RATE_TABLENAME', 'currency_rates'),
+    'retry' => [
+        'count' => env('FLEXMIND_CURRENCY_RATE_RETRY_COUNT', 3),
+        'sleep' => env('FLEXMIND_CURRENCY_RATE_RETRY_SLEEP', 1000),
+        'factor' => env('FLEXMIND_CURRENCY_RATE_RETRY_FACTOR', 2),
+    ],
 ];

--- a/tests/HttpFetcherTest.php
+++ b/tests/HttpFetcherTest.php
@@ -41,6 +41,44 @@ class HttpFetcherTest extends TestCase
     }
 
     /** @test */
+    public function fetch_retries_on_failure_and_returns_body()
+    {
+        Http::fake([
+            'example.com/*' => Http::sequence()
+                ->push('error', 500)
+                ->push('content', 200),
+        ]);
+
+        config()->set('currency-rate.retry.count', 3);
+        config()->set('currency-rate.retry.sleep', 0);
+        config()->set('currency-rate.retry.factor', 1);
+
+        $fetcher = $this->fetcher();
+
+        $this->assertEquals('content', $fetcher->callFetch('https://example.com/test'));
+        Http::assertSentCount(2);
+    }
+
+    /** @test */
+    public function fetch_returns_null_after_all_retries_fail()
+    {
+        Http::fake([
+            'example.com/*' => Http::sequence()
+                ->push('error', 500)
+                ->push('error', 500),
+        ]);
+
+        config()->set('currency-rate.retry.count', 2);
+        config()->set('currency-rate.retry.sleep', 0);
+        config()->set('currency-rate.retry.factor', 1);
+
+        $fetcher = $this->fetcher();
+
+        $this->assertNull($fetcher->callFetch('https://example.com/test'));
+        Http::assertSentCount(2);
+    }
+
+    /** @test */
     public function parse_xml_returns_simplexml_element()
     {
         $fetcher = $this->fetcher();


### PR DESCRIPTION
## Summary
- add configurable retry settings for HTTP fetcher
- implement exponential backoff using Laravel retry helper
- test retry success and failure scenarios

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68a55c887ffc8333b08cf966dce2700c