### PR TITLE
Parallelize rate downloads without queue

### DIFF
--- a/src/Jobs/QueueDownload.php
+++ b/src/Jobs/QueueDownload.php
@@ -5,6 +5,7 @@ namespace FlexMindSoftware\CurrencyRate\Jobs;
 use DateTime;
 use FlexMindSoftware\CurrencyRate\CurrencyRateFacade as CurrencyRate;
 use FlexMindSoftware\CurrencyRate\Models\CurrencyRate as CurrencyRateModel;
+use Illuminate\Bus\Batchable;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldBeUniqueUntilProcessing;
@@ -21,6 +22,7 @@ class QueueDownload implements ShouldQueue, ShouldBeUnique, ShouldBeUniqueUntilP
     use InteractsWithQueue;
     use Queueable;
     use SerializesModels;
+    use Batchable;
 
     /**
      * The number of seconds after which the job's unique lock will be released.

--- a/tests/MultipleDriversCommandTest.php
+++ b/tests/MultipleDriversCommandTest.php
@@ -7,6 +7,7 @@ use FlexMindSoftware\CurrencyRate\Jobs\QueueDownload;
 use FlexMindSoftware\CurrencyRate\Tests\Stubs\FakeDriver;
 use FlexMindSoftware\CurrencyRate\Tests\Stubs\SecondFakeDriver;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Queue;
 
 class MultipleDriversCommandTest extends TestCase
@@ -17,6 +18,11 @@ class MultipleDriversCommandTest extends TestCase
         file_put_contents(__DIR__.'/../database/database.sqlite', '');
         $migration = include __DIR__.'/../database/migrations/create_currency_rate_table.php.stub';
         $migration->up();
+        $batchMigrationClass = 'TestbenchCreateJobBatchesTable';
+        if (!class_exists($batchMigrationClass)) {
+            include __DIR__.'/../vendor/orchestra/testbench-core/laravel/migrations/queue/0001_01_01_000000_testbench_create_job_batches_table.php';
+        }
+        (new $batchMigrationClass())->up();
         CurrencyRate::extend(FakeDriver::DRIVER_NAME, fn () => new FakeDriver());
         CurrencyRate::extend(SecondFakeDriver::DRIVER_NAME, fn () => new SecondFakeDriver());
         config(['currency-rate.drivers' => [FakeDriver::DRIVER_NAME, SecondFakeDriver::DRIVER_NAME]]);
@@ -59,5 +65,23 @@ class MultipleDriversCommandTest extends TestCase
 
         $this->assertDatabaseHas('currency_rates', ['code' => 'USD']);
         $this->assertDatabaseHas('currency_rates', ['code' => 'GBP']);
+    }
+
+    /** @test */
+    public function it_batches_jobs_when_no_queue_and_multiple_drivers()
+    {
+        Bus::fake();
+
+        $this->artisan('flexmind:currency-rate', [
+            'date' => '2023-10-01',
+            '--driver' => 'all',
+            '--queue' => 'none',
+            '--connection' => 'testing',
+        ]);
+
+        Bus::assertBatchCount(1);
+        Bus::assertBatched(function ($batch) {
+            return count($batch->jobs) === 2;
+        });
     }
 }

--- a/tests/MultipleDriversCommandTest.php
+++ b/tests/MultipleDriversCommandTest.php
@@ -6,8 +6,8 @@ use FlexMindSoftware\CurrencyRate\CurrencyRateFacade as CurrencyRate;
 use FlexMindSoftware\CurrencyRate\Jobs\QueueDownload;
 use FlexMindSoftware\CurrencyRate\Tests\Stubs\FakeDriver;
 use FlexMindSoftware\CurrencyRate\Tests\Stubs\SecondFakeDriver;
-use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Queue;
 
 class MultipleDriversCommandTest extends TestCase
@@ -19,7 +19,7 @@ class MultipleDriversCommandTest extends TestCase
         $migration = include __DIR__.'/../database/migrations/create_currency_rate_table.php.stub';
         $migration->up();
         $batchMigrationClass = 'TestbenchCreateJobBatchesTable';
-        if (!class_exists($batchMigrationClass)) {
+        if (! class_exists($batchMigrationClass)) {
             include __DIR__.'/../vendor/orchestra/testbench-core/laravel/migrations/queue/0001_01_01_000000_testbench_create_job_batches_table.php';
         }
         (new $batchMigrationClass())->up();


### PR DESCRIPTION
## Summary
- Batch rate download jobs when running multiple drivers without a queue
- Support batching in `QueueDownload` job via `Batchable`
- Test batched execution and ensure job batch table exists

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68a563906fc483338d07aa724877e75d