### PR TITLE
Introduce CurrencyRateData DTO for rate records

### DIFF
--- a/src/DTO/CurrencyRateData.php
+++ b/src/DTO/CurrencyRateData.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace FlexMindSoftware\CurrencyRate\DTO;
+
+class CurrencyRateData
+{
+    public function __construct(
+        public string $driver,
+        public string $code,
+        public string $date,
+        public float $rate,
+        public float $multiplier = 1,
+        public ?string $no = null,
+    ) {
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'driver' => $this->driver,
+            'code' => strtoupper($this->code),
+            'date' => $this->date,
+            'rate' => $this->rate,
+            'multiplier' => $this->multiplier,
+            'no' => $this->no,
+        ];
+    }
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            driver: $data['driver'] ?? '',
+            code: $data['code'] ?? '',
+            date: $data['date'] ?? '',
+            rate: (float) ($data['rate'] ?? 0),
+            multiplier: (float) ($data['multiplier'] ?? 1),
+            no: $data['no'] ?? null,
+        );
+    }
+}

--- a/src/Models/CurrencyRate.php
+++ b/src/Models/CurrencyRate.php
@@ -2,6 +2,7 @@
 
 namespace FlexMindSoftware\CurrencyRate\Models;
 
+use FlexMindSoftware\CurrencyRate\DTO\CurrencyRateData;
 use FlexMindSoftware\CurrencyRate\Events\CurrencyRateSaved;
 use Illuminate\Database\Eloquent\Model;
 
@@ -35,7 +36,7 @@ class CurrencyRate extends Model
     ];
 
     /**
-     * @param array $data
+     * @param CurrencyRateData[] $data
      * @param string $connection
      */
     public static function saveIn(array $data, string $connection = 'default')
@@ -49,10 +50,14 @@ class CurrencyRate extends Model
             }
 
             foreach ($chunks as $chunk) {
-                static::on($connection)
-                    ->upsert($chunk, $columns, ['rate', 'no', 'multiplier']);
+                $mapped = array_map(function ($item) {
+                    return $item instanceof CurrencyRateData ? $item->toArray() : $item;
+                }, $chunk);
 
-                event(new CurrencyRateSaved($chunk));
+                static::on($connection)
+                    ->upsert($mapped, $columns, ['rate', 'no', 'multiplier']);
+
+                event(new CurrencyRateSaved($mapped));
             }
         }
     }

--- a/tests/CurrencyRateSaveInTest.php
+++ b/tests/CurrencyRateSaveInTest.php
@@ -2,6 +2,7 @@
 
 namespace FlexMindSoftware\CurrencyRate\Tests;
 
+use FlexMindSoftware\CurrencyRate\DTO\CurrencyRateData;
 use FlexMindSoftware\CurrencyRate\Events\CurrencyRateSaved;
 use FlexMindSoftware\CurrencyRate\Models\CurrencyRate;
 use Illuminate\Support\Facades\Event;
@@ -22,22 +23,22 @@ class CurrencyRateSaveInTest extends TestCase
         Event::fake();
 
         $data = [
-            [
-                'driver' => 'test',
-                'code' => 'USD',
-                'date' => '2023-10-01',
-                'rate' => 1.1,
-                'multiplier' => 1,
-                'no' => null,
-            ],
-            [
-                'driver' => 'test',
-                'code' => 'PLN',
-                'date' => '2023-10-01',
-                'rate' => 4.4,
-                'multiplier' => 1,
-                'no' => null,
-            ],
+            new CurrencyRateData(
+                driver: 'test',
+                code: 'USD',
+                date: '2023-10-01',
+                rate: 1.1,
+                multiplier: 1,
+                no: null,
+            ),
+            new CurrencyRateData(
+                driver: 'test',
+                code: 'PLN',
+                date: '2023-10-01',
+                rate: 4.4,
+                multiplier: 1,
+                no: null,
+            ),
         ];
 
         CurrencyRate::saveIn($data, 'testing');
@@ -46,7 +47,8 @@ class CurrencyRateSaveInTest extends TestCase
         $this->assertDatabaseHas('currency_rates', ['code' => 'PLN']);
 
         Event::assertDispatched(CurrencyRateSaved::class, function ($event) use ($data) {
-            return $event->rates === $data;
+            $expected = array_map(fn($d) => $d->toArray(), $data);
+            return $event->rates === $expected;
         });
     }
 }

--- a/tests/FakeDriverTest.php
+++ b/tests/FakeDriverTest.php
@@ -27,7 +27,7 @@ class FakeDriverTest extends TestCase
 
         $data = $driver->retrieveData();
 
-        $this->assertEquals('USD', $data[0]['code']);
-        $this->assertEquals(1.1, $data[0]['rate']);
+        $this->assertEquals('USD', $data[0]->code);
+        $this->assertEquals(1.1, $data[0]->rate);
     }
 }

--- a/tests/Stubs/FakeDriver.php
+++ b/tests/Stubs/FakeDriver.php
@@ -3,6 +3,7 @@
 namespace FlexMindSoftware\CurrencyRate\Tests\Stubs;
 
 use FlexMindSoftware\CurrencyRate\Contracts\CurrencyInterface;
+use FlexMindSoftware\CurrencyRate\DTO\CurrencyRateData;
 use FlexMindSoftware\CurrencyRate\Drivers\BaseDriver;
 use FlexMindSoftware\CurrencyRate\Enums\CurrencyCode;
 use FlexMindSoftware\CurrencyRate\Models\RateTrait;
@@ -19,14 +20,14 @@ class FakeDriver extends BaseDriver implements CurrencyInterface
     {
         $this->fetch(static::URI);
 
-        $this->data[] = [
-            'driver' => self::DRIVER_NAME,
-            'code' => 'USD',
-            'date' => '2023-10-01',
-            'rate' => 1.1,
-            'multiplier' => 1,
-            'no' => null,
-        ];
+        $this->data[] = new CurrencyRateData(
+            driver: self::DRIVER_NAME,
+            code: 'USD',
+            date: '2023-10-01',
+            rate: 1.1,
+            multiplier: 1,
+            no: null,
+        );
 
         return $this;
     }

--- a/tests/Stubs/SecondFakeDriver.php
+++ b/tests/Stubs/SecondFakeDriver.php
@@ -3,6 +3,7 @@
 namespace FlexMindSoftware\CurrencyRate\Tests\Stubs;
 
 use FlexMindSoftware\CurrencyRate\Contracts\CurrencyInterface;
+use FlexMindSoftware\CurrencyRate\DTO\CurrencyRateData;
 use FlexMindSoftware\CurrencyRate\Drivers\BaseDriver;
 use FlexMindSoftware\CurrencyRate\Enums\CurrencyCode;
 use FlexMindSoftware\CurrencyRate\Models\RateTrait;
@@ -19,14 +20,14 @@ class SecondFakeDriver extends BaseDriver implements CurrencyInterface
     {
         $this->fetch(static::URI);
 
-        $this->data[] = [
-            'driver' => self::DRIVER_NAME,
-            'code' => 'GBP',
-            'date' => '2023-10-01',
-            'rate' => 1.2,
-            'multiplier' => 1,
-            'no' => null,
-        ];
+        $this->data[] = new CurrencyRateData(
+            driver: self::DRIVER_NAME,
+            code: 'GBP',
+            date: '2023-10-01',
+            rate: 1.2,
+            multiplier: 1,
+            no: null,
+        );
 
         return $this;
     }


### PR DESCRIPTION
## Summary
- add `CurrencyRateData` DTO encapsulating driver, code, date, rate, and multiplier
- refactor base driver and `CurrencyRate` model to consume DTO objects
- update test stubs and expectations for new DTO

## Testing
- `composer test`
- `composer psalm` *(fails: NullableReturnStatement and other issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a565f7fd54833393d5473679bc919c