### PR TITLE
chore: enable strict types

### DIFF
--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Database\Factories;
 

--- a/src/Commands/CurrencyRateCommand.php
+++ b/src/Commands/CurrencyRateCommand.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Commands;

--- a/src/Commands/CurrencyRateCommand.php
+++ b/src/Commands/CurrencyRateCommand.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Commands;
 

--- a/src/Contracts/CurrencyInterface.php
+++ b/src/Contracts/CurrencyInterface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Contracts;
 

--- a/src/Contracts/CurrencyInterface.php
+++ b/src/Contracts/CurrencyInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Contracts;

--- a/src/Contracts/DriverMetadata.php
+++ b/src/Contracts/DriverMetadata.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Contracts;
 

--- a/src/Contracts/DriverMetadata.php
+++ b/src/Contracts/DriverMetadata.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Contracts;

--- a/src/CurrencyRateFacade.php
+++ b/src/CurrencyRateFacade.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate;
 

--- a/src/CurrencyRateFacade.php
+++ b/src/CurrencyRateFacade.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate;

--- a/src/CurrencyRateManager.php
+++ b/src/CurrencyRateManager.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate;
 

--- a/src/CurrencyRateManager.php
+++ b/src/CurrencyRateManager.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate;

--- a/src/CurrencyRateServiceProvider.php
+++ b/src/CurrencyRateServiceProvider.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate;
 

--- a/src/CurrencyRateServiceProvider.php
+++ b/src/CurrencyRateServiceProvider.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate;

--- a/src/DTO/CurrencyRateData.php
+++ b/src/DTO/CurrencyRateData.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\DTO;
 

--- a/src/DTO/CurrencyRateData.php
+++ b/src/DTO/CurrencyRateData.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\DTO;

--- a/src/Drivers/AlbaniaDriver.php
+++ b/src/Drivers/AlbaniaDriver.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;

--- a/src/Drivers/AlbaniaDriver.php
+++ b/src/Drivers/AlbaniaDriver.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;
 

--- a/src/Drivers/ArmeniaDriver.php
+++ b/src/Drivers/ArmeniaDriver.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;

--- a/src/Drivers/ArmeniaDriver.php
+++ b/src/Drivers/ArmeniaDriver.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;
 

--- a/src/Drivers/AustraliaDriver.php
+++ b/src/Drivers/AustraliaDriver.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;

--- a/src/Drivers/AustraliaDriver.php
+++ b/src/Drivers/AustraliaDriver.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;
 

--- a/src/Drivers/AzerbaijanDriver.php
+++ b/src/Drivers/AzerbaijanDriver.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;

--- a/src/Drivers/AzerbaijanDriver.php
+++ b/src/Drivers/AzerbaijanDriver.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;
 

--- a/src/Drivers/BaseDriver.php
+++ b/src/Drivers/BaseDriver.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;

--- a/src/Drivers/BaseDriver.php
+++ b/src/Drivers/BaseDriver.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;
 

--- a/src/Drivers/BceaoDriver.php
+++ b/src/Drivers/BceaoDriver.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;

--- a/src/Drivers/BceaoDriver.php
+++ b/src/Drivers/BceaoDriver.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;
 

--- a/src/Drivers/BelarusDriver.php
+++ b/src/Drivers/BelarusDriver.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;

--- a/src/Drivers/BelarusDriver.php
+++ b/src/Drivers/BelarusDriver.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;
 

--- a/src/Drivers/BosniaAndHerzegovinaDriver.php
+++ b/src/Drivers/BosniaAndHerzegovinaDriver.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;

--- a/src/Drivers/BosniaAndHerzegovinaDriver.php
+++ b/src/Drivers/BosniaAndHerzegovinaDriver.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;
 

--- a/src/Drivers/BotswanaDriver.php
+++ b/src/Drivers/BotswanaDriver.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;

--- a/src/Drivers/BotswanaDriver.php
+++ b/src/Drivers/BotswanaDriver.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;
 

--- a/src/Drivers/BulgariaDriver.php
+++ b/src/Drivers/BulgariaDriver.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;

--- a/src/Drivers/BulgariaDriver.php
+++ b/src/Drivers/BulgariaDriver.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;
 

--- a/src/Drivers/CanadaDriver.php
+++ b/src/Drivers/CanadaDriver.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;

--- a/src/Drivers/CanadaDriver.php
+++ b/src/Drivers/CanadaDriver.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;
 

--- a/src/Drivers/ChinaDriver.php
+++ b/src/Drivers/ChinaDriver.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;

--- a/src/Drivers/ChinaDriver.php
+++ b/src/Drivers/ChinaDriver.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;
 

--- a/src/Drivers/CroatiaDriver.php
+++ b/src/Drivers/CroatiaDriver.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;

--- a/src/Drivers/CroatiaDriver.php
+++ b/src/Drivers/CroatiaDriver.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;
 

--- a/src/Drivers/CzechRepublicDriver.php
+++ b/src/Drivers/CzechRepublicDriver.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;

--- a/src/Drivers/CzechRepublicDriver.php
+++ b/src/Drivers/CzechRepublicDriver.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;
 

--- a/src/Drivers/DenmarkDriver.php
+++ b/src/Drivers/DenmarkDriver.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;

--- a/src/Drivers/DenmarkDriver.php
+++ b/src/Drivers/DenmarkDriver.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;
 

--- a/src/Drivers/DummyDriver.php
+++ b/src/Drivers/DummyDriver.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;

--- a/src/Drivers/DummyDriver.php
+++ b/src/Drivers/DummyDriver.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;
 

--- a/src/Drivers/EnglandDriver.php
+++ b/src/Drivers/EnglandDriver.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;

--- a/src/Drivers/EnglandDriver.php
+++ b/src/Drivers/EnglandDriver.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;
 

--- a/src/Drivers/EuropeanCentralBankDriver.php
+++ b/src/Drivers/EuropeanCentralBankDriver.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;

--- a/src/Drivers/EuropeanCentralBankDriver.php
+++ b/src/Drivers/EuropeanCentralBankDriver.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;
 

--- a/src/Drivers/FijiDriver.php
+++ b/src/Drivers/FijiDriver.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;

--- a/src/Drivers/FijiDriver.php
+++ b/src/Drivers/FijiDriver.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;
 

--- a/src/Drivers/GeorgiaDriver.php
+++ b/src/Drivers/GeorgiaDriver.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;

--- a/src/Drivers/GeorgiaDriver.php
+++ b/src/Drivers/GeorgiaDriver.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;
 

--- a/src/Drivers/HttpFetcher.php
+++ b/src/Drivers/HttpFetcher.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;

--- a/src/Drivers/HttpFetcher.php
+++ b/src/Drivers/HttpFetcher.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;
 

--- a/src/Drivers/HungaryDriver.php
+++ b/src/Drivers/HungaryDriver.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;

--- a/src/Drivers/HungaryDriver.php
+++ b/src/Drivers/HungaryDriver.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;
 

--- a/src/Drivers/IcelandDriver.php
+++ b/src/Drivers/IcelandDriver.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;

--- a/src/Drivers/IcelandDriver.php
+++ b/src/Drivers/IcelandDriver.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;
 

--- a/src/Drivers/IsraelDriver.php
+++ b/src/Drivers/IsraelDriver.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;

--- a/src/Drivers/IsraelDriver.php
+++ b/src/Drivers/IsraelDriver.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;
 

--- a/src/Drivers/MacedoniaDriver.php
+++ b/src/Drivers/MacedoniaDriver.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;

--- a/src/Drivers/MacedoniaDriver.php
+++ b/src/Drivers/MacedoniaDriver.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;
 

--- a/src/Drivers/MoldaviaDriver.php
+++ b/src/Drivers/MoldaviaDriver.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;

--- a/src/Drivers/MoldaviaDriver.php
+++ b/src/Drivers/MoldaviaDriver.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;
 

--- a/src/Drivers/NorwayDriver.php
+++ b/src/Drivers/NorwayDriver.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;

--- a/src/Drivers/NorwayDriver.php
+++ b/src/Drivers/NorwayDriver.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;
 

--- a/src/Drivers/PolandDriver.php
+++ b/src/Drivers/PolandDriver.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;

--- a/src/Drivers/PolandDriver.php
+++ b/src/Drivers/PolandDriver.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;
 

--- a/src/Drivers/RomaniaDriver.php
+++ b/src/Drivers/RomaniaDriver.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;

--- a/src/Drivers/RomaniaDriver.php
+++ b/src/Drivers/RomaniaDriver.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;
 

--- a/src/Drivers/RussiaDriver.php
+++ b/src/Drivers/RussiaDriver.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;

--- a/src/Drivers/RussiaDriver.php
+++ b/src/Drivers/RussiaDriver.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;
 

--- a/src/Drivers/SerbiaDriver.php
+++ b/src/Drivers/SerbiaDriver.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;

--- a/src/Drivers/SerbiaDriver.php
+++ b/src/Drivers/SerbiaDriver.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;
 

--- a/src/Drivers/SwedenDriver.php
+++ b/src/Drivers/SwedenDriver.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;

--- a/src/Drivers/SwedenDriver.php
+++ b/src/Drivers/SwedenDriver.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;
 

--- a/src/Drivers/SwitzerlandDriver.php
+++ b/src/Drivers/SwitzerlandDriver.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;

--- a/src/Drivers/SwitzerlandDriver.php
+++ b/src/Drivers/SwitzerlandDriver.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;
 

--- a/src/Drivers/TurkeyDriver.php
+++ b/src/Drivers/TurkeyDriver.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;

--- a/src/Drivers/TurkeyDriver.php
+++ b/src/Drivers/TurkeyDriver.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;
 

--- a/src/Drivers/UkraineDriver.php
+++ b/src/Drivers/UkraineDriver.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;

--- a/src/Drivers/UkraineDriver.php
+++ b/src/Drivers/UkraineDriver.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;
 

--- a/src/Enums/CurrencyCode.php
+++ b/src/Enums/CurrencyCode.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Enums;

--- a/src/Enums/CurrencyCode.php
+++ b/src/Enums/CurrencyCode.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Enums;
 

--- a/src/Events/CurrencyRateSaved.php
+++ b/src/Events/CurrencyRateSaved.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Events;
 

--- a/src/Events/CurrencyRateSaved.php
+++ b/src/Events/CurrencyRateSaved.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Events;

--- a/src/Jobs/QueueDownload.php
+++ b/src/Jobs/QueueDownload.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Jobs;

--- a/src/Jobs/QueueDownload.php
+++ b/src/Jobs/QueueDownload.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Jobs;
 

--- a/src/Models/Country.php
+++ b/src/Models/Country.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Models;

--- a/src/Models/Country.php
+++ b/src/Models/Country.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Models;
 

--- a/src/Models/Currency.php
+++ b/src/Models/Currency.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Models;

--- a/src/Models/Currency.php
+++ b/src/Models/Currency.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Models;
 

--- a/src/Models/CurrencyRate.php
+++ b/src/Models/CurrencyRate.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Models;

--- a/src/Models/CurrencyRate.php
+++ b/src/Models/CurrencyRate.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Models;
 

--- a/src/Models/RateTrait.php
+++ b/src/Models/RateTrait.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Models;

--- a/src/Models/RateTrait.php
+++ b/src/Models/RateTrait.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Models;
 

--- a/tests/ArmeniaDriverTest.php
+++ b/tests/ArmeniaDriverTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Tests;
 

--- a/tests/ArmeniaDriverTest.php
+++ b/tests/ArmeniaDriverTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Tests;

--- a/tests/AzerbaijanDriverTest.php
+++ b/tests/AzerbaijanDriverTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Tests;
 

--- a/tests/AzerbaijanDriverTest.php
+++ b/tests/AzerbaijanDriverTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Tests;

--- a/tests/BceaoDriverTest.php
+++ b/tests/BceaoDriverTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Tests;
 

--- a/tests/BceaoDriverTest.php
+++ b/tests/BceaoDriverTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Tests;

--- a/tests/BelarusDriverTest.php
+++ b/tests/BelarusDriverTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Tests;
 

--- a/tests/BelarusDriverTest.php
+++ b/tests/BelarusDriverTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Tests;

--- a/tests/BosniaAndHerzegovinaDriverTest.php
+++ b/tests/BosniaAndHerzegovinaDriverTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Tests;
 

--- a/tests/BosniaAndHerzegovinaDriverTest.php
+++ b/tests/BosniaAndHerzegovinaDriverTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Tests;

--- a/tests/BotswanaDriverTest.php
+++ b/tests/BotswanaDriverTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Tests;
 

--- a/tests/BotswanaDriverTest.php
+++ b/tests/BotswanaDriverTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Tests;

--- a/tests/BulgariaDriverTest.php
+++ b/tests/BulgariaDriverTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Tests;
 

--- a/tests/BulgariaDriverTest.php
+++ b/tests/BulgariaDriverTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Tests;

--- a/tests/CanadaDriverTest.php
+++ b/tests/CanadaDriverTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Tests;
 

--- a/tests/CanadaDriverTest.php
+++ b/tests/CanadaDriverTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Tests;

--- a/tests/ChinaDriverTest.php
+++ b/tests/ChinaDriverTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Tests;
 

--- a/tests/ChinaDriverTest.php
+++ b/tests/ChinaDriverTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Tests;

--- a/tests/ConfigValidatorTest.php
+++ b/tests/ConfigValidatorTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Tests;
 

--- a/tests/ConfigValidatorTest.php
+++ b/tests/ConfigValidatorTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Tests;

--- a/tests/CurrencyRateCommandTest.php
+++ b/tests/CurrencyRateCommandTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Tests;
 

--- a/tests/CurrencyRateCommandTest.php
+++ b/tests/CurrencyRateCommandTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Tests;

--- a/tests/CurrencyRateSaveInTest.php
+++ b/tests/CurrencyRateSaveInTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Tests;
 

--- a/tests/CurrencyRateSaveInTest.php
+++ b/tests/CurrencyRateSaveInTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Tests;

--- a/tests/CzechRepublicDriverTest.php
+++ b/tests/CzechRepublicDriverTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Tests;
 

--- a/tests/CzechRepublicDriverTest.php
+++ b/tests/CzechRepublicDriverTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Tests;

--- a/tests/DriverMetadataTest.php
+++ b/tests/DriverMetadataTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Tests;
 

--- a/tests/DriverMetadataTest.php
+++ b/tests/DriverMetadataTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Tests;

--- a/tests/EuropeanCentralBankDriverTest.php
+++ b/tests/EuropeanCentralBankDriverTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Tests;
 

--- a/tests/EuropeanCentralBankDriverTest.php
+++ b/tests/EuropeanCentralBankDriverTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Tests;

--- a/tests/ExampleTest.php
+++ b/tests/ExampleTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Tests;
 

--- a/tests/ExampleTest.php
+++ b/tests/ExampleTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Tests;

--- a/tests/FakeDriverTest.php
+++ b/tests/FakeDriverTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Tests;
 

--- a/tests/FakeDriverTest.php
+++ b/tests/FakeDriverTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Tests;

--- a/tests/GeorgiaDriverTest.php
+++ b/tests/GeorgiaDriverTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Tests;
 

--- a/tests/GeorgiaDriverTest.php
+++ b/tests/GeorgiaDriverTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Tests;

--- a/tests/HttpFetcherTest.php
+++ b/tests/HttpFetcherTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Tests;
 

--- a/tests/HttpFetcherTest.php
+++ b/tests/HttpFetcherTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Tests;

--- a/tests/HungaryDriverTest.php
+++ b/tests/HungaryDriverTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Tests;
 

--- a/tests/HungaryDriverTest.php
+++ b/tests/HungaryDriverTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Tests;

--- a/tests/IsraelDriverTest.php
+++ b/tests/IsraelDriverTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Tests;
 

--- a/tests/IsraelDriverTest.php
+++ b/tests/IsraelDriverTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Tests;

--- a/tests/MultipleDriversCommandTest.php
+++ b/tests/MultipleDriversCommandTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Tests;
 

--- a/tests/MultipleDriversCommandTest.php
+++ b/tests/MultipleDriversCommandTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Tests;

--- a/tests/NorwayDriverTest.php
+++ b/tests/NorwayDriverTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Tests;
 

--- a/tests/NorwayDriverTest.php
+++ b/tests/NorwayDriverTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Tests;

--- a/tests/PolandDriverTest.php
+++ b/tests/PolandDriverTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Tests;
 

--- a/tests/PolandDriverTest.php
+++ b/tests/PolandDriverTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Tests;

--- a/tests/QueueDownloadTest.php
+++ b/tests/QueueDownloadTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Tests;
 

--- a/tests/QueueDownloadTest.php
+++ b/tests/QueueDownloadTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Tests;

--- a/tests/RateTraitTest.php
+++ b/tests/RateTraitTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Tests;
 

--- a/tests/RateTraitTest.php
+++ b/tests/RateTraitTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Tests;

--- a/tests/RomaniaDriverTest.php
+++ b/tests/RomaniaDriverTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Tests;
 

--- a/tests/RomaniaDriverTest.php
+++ b/tests/RomaniaDriverTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Tests;

--- a/tests/Stubs/FakeDriver.php
+++ b/tests/Stubs/FakeDriver.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Tests\Stubs;

--- a/tests/Stubs/FakeDriver.php
+++ b/tests/Stubs/FakeDriver.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Tests\Stubs;
 

--- a/tests/Stubs/SecondFakeDriver.php
+++ b/tests/Stubs/SecondFakeDriver.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Tests\Stubs;

--- a/tests/Stubs/SecondFakeDriver.php
+++ b/tests/Stubs/SecondFakeDriver.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Tests\Stubs;
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Tests;
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Tests;


### PR DESCRIPTION
## Summary
- add `declare(strict_types=1);` to all PHP files

## Testing
- `composer test` *(fails: 7 failed, 35 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a5b4346b048333900ff31bd5383616