### PR TITLE
Add frequency info for currency rate drivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,40 +78,40 @@ the drivers used in your application. See [config/currency-rate.php](config/curr
 
 ### Available Drivers
 
-| Country / Source | Driver |
-|------------------|--------|
-| Albania | `albania` |
-| Armenia | `armenia` |
-| Australia | `australia` |
-| Azerbaijan | `azerbaijan` |
-| BCEAO | `bceao` |
-| Belarus | `belarus` |
-| Bosnia and Herzegovina | `bosnia-and-herzegovina` |
-| Botswana | `botswana` |
-| Bulgaria | `bulgaria` |
-| Canada | `canada` |
-| China | `china` |
-| Croatia | `croatia` |
-| Czech Republic | `czech-republic` |
-| Denmark | `denmark` |
-| England | `england` |
-| European Central Bank | `european-central-bank` |
-| Fiji | `fiji` |
-| Georgia | `georgia` |
-| Hungary | `hungary` |
-| Iceland | `iceland` |
-| Israel | `israel` |
-| Macedonia | `macedonia` |
-| Moldavia | `moldavia` |
-| Norway | `norway` |
-| Poland | `poland` |
-| Romania | `romania` |
-| Russia | `russia` |
-| Serbia | `serbia` |
-| Sweden | `sweden` |
-| Switzerland | `switzerland` |
-| Turkey | `turkey` |
-| Ukraine | `ukraine` |
+| Country / Source | Driver | Frequency |
+|------------------|--------|-----------|
+| Albania | `albania` | Daily on business days |
+| Armenia | `armenia` | Daily on business days |
+| Australia | `australia` | Weekdays around 4:00 PM Eastern Australian Time |
+| Azerbaijan | `azerbaijan` | Daily on business days |
+| BCEAO | `bceao` | Daily on business days |
+| Belarus | `belarus` | Daily on business days |
+| Bosnia and Herzegovina | `bosnia-and-herzegovina` | Daily on business days |
+| Botswana | `botswana` | Daily on business days |
+| Bulgaria | `bulgaria` | Daily on business days |
+| Canada | `canada` | Daily on business days |
+| China | `china` | Daily on business days |
+| Croatia | `croatia` | Daily on business days |
+| Czech Republic | `czech-republic` | Daily on business days |
+| Denmark | `denmark` | Daily on business days |
+| England | `england` | Daily on business days |
+| European Central Bank | `european-central-bank` | Weekdays at 3:00 PM CET |
+| Fiji | `fiji` | Official rate set at 8:30 AM FJT each business day |
+| Georgia | `georgia` | Daily on business days |
+| Hungary | `hungary` | Daily on business days |
+| Iceland | `iceland` | Daily on business days |
+| Israel | `israel` | Daily on business days |
+| Macedonia | `macedonia` | Daily on business days |
+| Moldavia | `moldavia` | Daily on business days |
+| Norway | `norway` | Daily on business days |
+| Poland | `poland` | Tables A/B/C: business days; B on Wednesdays; C at 7:45–8:15 AM |
+| Romania | `romania` | Daily on business days |
+| Russia | `russia` | Daily on business days |
+| Serbia | `serbia` | Weekdays at 8:00 CET; weekends use last working day |
+| Sweden | `sweden` | Daily on business days |
+| Switzerland | `switzerland` | Weekdays at 11:00 AM CET |
+| Turkey | `turkey` | Daily on business days |
+| Ukraine | `ukraine` | Daily on business days |
 
 ## Usage
 

--- a/resources/langs/en/description.php
+++ b/resources/langs/en/description.php
@@ -2,46 +2,49 @@
 
 return [
     'albania' => [
-        'frequency' => '',
+        'frequency' => 'Daily on business days',
     ],
     'armenia' => [
-        'frequency' => '',
+        'frequency' => 'Daily on business days',
     ],
     'australia' => [
         'frequency' => 'Weekdays around 4:00 PM Eastern Australian Time',
     ],
+    'azerbaijan' => [
+        'frequency' => 'Daily on business days',
+    ],
     'bceao' => [
-        'frequency' => '',
+        'frequency' => 'Daily on business days',
     ],
     'belarus' => [
-        'frequency' => '',
+        'frequency' => 'Daily on business days',
     ],
     'bosnia-and-herzegovina' => [
-        'frequency' => '',
+        'frequency' => 'Daily on business days',
     ],
     'botswana' => [
-        'frequency' => '',
+        'frequency' => 'Daily on business days',
     ],
     'bulgaria' => [
-        'frequency' => '',
+        'frequency' => 'Daily on business days',
     ],
     'canada' => [
-        'frequency' => '',
+        'frequency' => 'Daily on business days',
     ],
     'china' => [
-        'frequency' => '',
+        'frequency' => 'Daily on business days',
     ],
     'croatia' => [
-        'frequency' => '',
+        'frequency' => 'Daily on business days',
     ],
     'czech-republic' => [
-        'frequency' => '',
+        'frequency' => 'Daily on business days',
     ],
     'denmark' => [
-        'frequency' => '',
+        'frequency' => 'Daily on business days',
     ],
     'england' => [
-        'frequency' => '',
+        'frequency' => 'Daily on business days',
     ],
     'european-central-bank' => [
         'frequency' => 'Weekday at 3:00 PM Central European Time (CET)',
@@ -55,25 +58,25 @@ return [
             'currencies against the FJD.',
     ],
     'georgia' => [
-        'frequency' => '',
+        'frequency' => 'Daily on business days',
     ],
     'hungary' => [
-        'frequency' => '',
+        'frequency' => 'Daily on business days',
     ],
     'iceland' => [
-        'frequency' => '',
+        'frequency' => 'Daily on business days',
     ],
     'israel' => [
-        'frequency' => '',
+        'frequency' => 'Daily on business days',
     ],
     'macedonia' => [
-        'frequency' => '',
+        'frequency' => 'Daily on business days',
     ],
     'moldavia' => [
-        'frequency' => '',
+        'frequency' => 'Daily on business days',
     ],
     'norway' => [
-        'frequency' => '',
+        'frequency' => 'Daily on business days',
     ],
     'poland' => [
         'frequency' => 'Table A of the average foreign currency exchange rates is published (updated) on the ' .
@@ -84,25 +87,25 @@ return [
             'between 7:45 a.m. and 8:15 a.m.',
     ],
     'romania' => [
-        'frequency' => '',
+        'frequency' => 'Daily on business days',
     ],
     'russia' => [
-        'frequency' => '',
+        'frequency' => 'Daily on business days',
     ],
     'serbia' => [
         'frequency' => 'Weekday at 8:00 CET. On weekends and public holidays, a list of exchange rates ' .
             'for the last working day',
     ],
     'sweden' => [
-        'frequency' => '',
+        'frequency' => 'Daily on business days',
     ],
     'switzerland' => [
         'frequency' => 'Weekday at 11:00 AM Central European Time (CET)',
     ],
     'turkey' => [
-        'frequency' => '',
+        'frequency' => 'Daily on business days',
     ],
     'ukraine' => [
-        'frequency' => '',
+        'frequency' => 'Daily on business days',
     ],
 ];

--- a/resources/langs/es/description.php
+++ b/resources/langs/es/description.php
@@ -2,46 +2,49 @@
 
 return [
     'albania' => [
-        'frequency' => '',
+        'frequency' => 'Diariamente en días laborables',
     ],
     'armenia' => [
-        'frequency' => '',
+        'frequency' => 'Diariamente en días laborables',
     ],
     'australia' => [
         'frequency' => 'Días laborables alrededor de las 16:00 hora del este de Australia',
     ],
+    'azerbaijan' => [
+        'frequency' => 'Diariamente en días laborables',
+    ],
     'bceao' => [
-        'frequency' => '',
+        'frequency' => 'Diariamente en días laborables',
     ],
     'belarus' => [
-        'frequency' => '',
+        'frequency' => 'Diariamente en días laborables',
     ],
     'bosnia-and-herzegovina' => [
-        'frequency' => '',
+        'frequency' => 'Diariamente en días laborables',
     ],
     'botswana' => [
-        'frequency' => '',
+        'frequency' => 'Diariamente en días laborables',
     ],
     'bulgaria' => [
-        'frequency' => '',
+        'frequency' => 'Diariamente en días laborables',
     ],
     'canada' => [
-        'frequency' => '',
+        'frequency' => 'Diariamente en días laborables',
     ],
     'china' => [
-        'frequency' => '',
+        'frequency' => 'Diariamente en días laborables',
     ],
     'croatia' => [
-        'frequency' => '',
+        'frequency' => 'Diariamente en días laborables',
     ],
     'czech-republic' => [
-        'frequency' => '',
+        'frequency' => 'Diariamente en días laborables',
     ],
     'denmark' => [
-        'frequency' => '',
+        'frequency' => 'Diariamente en días laborables',
     ],
     'england' => [
-        'frequency' => '',
+        'frequency' => 'Diariamente en días laborables',
     ],
     'european-central-bank' => [
         'frequency' => 'Día laborable a las 15:00 hora de Europa Central (CET)',
@@ -55,25 +58,25 @@ return [
             'monedas frente al FJD.',
     ],
     'georgia' => [
-        'frequency' => '',
+        'frequency' => 'Diariamente en días laborables',
     ],
     'hungary' => [
-        'frequency' => '',
+        'frequency' => 'Diariamente en días laborables',
     ],
     'iceland' => [
-        'frequency' => '',
+        'frequency' => 'Diariamente en días laborables',
     ],
     'israel' => [
-        'frequency' => '',
+        'frequency' => 'Diariamente en días laborables',
     ],
     'macedonia' => [
-        'frequency' => '',
+        'frequency' => 'Diariamente en días laborables',
     ],
     'moldavia' => [
-        'frequency' => '',
+        'frequency' => 'Diariamente en días laborables',
     ],
     'norway' => [
-        'frequency' => '',
+        'frequency' => 'Diariamente en días laborables',
     ],
     'poland' => [
         'frequency' => 'La Tabla A de los tipos de cambio medios de divisas se publica (actualiza) en el sitio web del NBP ' .
@@ -84,25 +87,25 @@ return [
             '7:45 a.m. y las 8:15 a.m.',
     ],
     'romania' => [
-        'frequency' => '',
+        'frequency' => 'Diariamente en días laborables',
     ],
     'russia' => [
-        'frequency' => '',
+        'frequency' => 'Diariamente en días laborables',
     ],
     'serbia' => [
         'frequency' => 'Día laborable a las 8:00 CET. En fines de semana y días festivos, una lista de tipos de cambio ' .
             'del último día laborable',
     ],
     'sweden' => [
-        'frequency' => '',
+        'frequency' => 'Diariamente en días laborables',
     ],
     'switzerland' => [
         'frequency' => 'Día laborable a las 11:00 AM hora de Europa Central (CET)',
     ],
     'turkey' => [
-        'frequency' => '',
+        'frequency' => 'Diariamente en días laborables',
     ],
     'ukraine' => [
-        'frequency' => '',
+        'frequency' => 'Diariamente en días laborables',
     ],
 ];

--- a/resources/langs/fr/description.php
+++ b/resources/langs/fr/description.php
@@ -2,46 +2,49 @@
 
 return [
     'albania' => [
-        'frequency' => '',
+        'frequency' => 'Quotidiennement les jours ouvrables',
     ],
     'armenia' => [
-        'frequency' => '',
+        'frequency' => 'Quotidiennement les jours ouvrables',
     ],
     'australia' => [
         'frequency' => 'Jours ouvrables vers 16h00 heure de l\'est de l\'Australie',
     ],
+    'azerbaijan' => [
+        'frequency' => 'Quotidiennement les jours ouvrables',
+    ],
     'bceao' => [
-        'frequency' => '',
+        'frequency' => 'Quotidiennement les jours ouvrables',
     ],
     'belarus' => [
-        'frequency' => '',
+        'frequency' => 'Quotidiennement les jours ouvrables',
     ],
     'bosnia-and-herzegovina' => [
-        'frequency' => '',
+        'frequency' => 'Quotidiennement les jours ouvrables',
     ],
     'botswana' => [
-        'frequency' => '',
+        'frequency' => 'Quotidiennement les jours ouvrables',
     ],
     'bulgaria' => [
-        'frequency' => '',
+        'frequency' => 'Quotidiennement les jours ouvrables',
     ],
     'canada' => [
-        'frequency' => '',
+        'frequency' => 'Quotidiennement les jours ouvrables',
     ],
     'china' => [
-        'frequency' => '',
+        'frequency' => 'Quotidiennement les jours ouvrables',
     ],
     'croatia' => [
-        'frequency' => '',
+        'frequency' => 'Quotidiennement les jours ouvrables',
     ],
     'czech-republic' => [
-        'frequency' => '',
+        'frequency' => 'Quotidiennement les jours ouvrables',
     ],
     'denmark' => [
-        'frequency' => '',
+        'frequency' => 'Quotidiennement les jours ouvrables',
     ],
     'england' => [
-        'frequency' => '',
+        'frequency' => 'Quotidiennement les jours ouvrables',
     ],
     'european-central-bank' => [
         'frequency' => 'Jour ouvrable à 15h00 heure d\'Europe centrale (CET)',
@@ -55,25 +58,25 @@ return [
             'monnaies par rapport au FJD.',
     ],
     'georgia' => [
-        'frequency' => '',
+        'frequency' => 'Quotidiennement les jours ouvrables',
     ],
     'hungary' => [
-        'frequency' => '',
+        'frequency' => 'Quotidiennement les jours ouvrables',
     ],
     'iceland' => [
-        'frequency' => '',
+        'frequency' => 'Quotidiennement les jours ouvrables',
     ],
     'israel' => [
-        'frequency' => '',
+        'frequency' => 'Quotidiennement les jours ouvrables',
     ],
     'macedonia' => [
-        'frequency' => '',
+        'frequency' => 'Quotidiennement les jours ouvrables',
     ],
     'moldavia' => [
-        'frequency' => '',
+        'frequency' => 'Quotidiennement les jours ouvrables',
     ],
     'norway' => [
-        'frequency' => '',
+        'frequency' => 'Quotidiennement les jours ouvrables',
     ],
     'poland' => [
         'frequency' => 'La table A des taux de change moyens des devises étrangères est publiée (mise à jour) sur le site de la NBP ' .
@@ -83,25 +86,25 @@ return [
             '(mises à jour) sur le site de la NBP les jours ouvrables entre 7h45 et 8h15.',
     ],
     'romania' => [
-        'frequency' => '',
+        'frequency' => 'Quotidiennement les jours ouvrables',
     ],
     'russia' => [
-        'frequency' => '',
+        'frequency' => 'Quotidiennement les jours ouvrables',
     ],
     'serbia' => [
         'frequency' => 'Jour ouvrable à 8h00 CET. Les week-ends et jours fériés, une liste des taux de change pour le dernier jour ' .
             'ouvrable',
     ],
     'sweden' => [
-        'frequency' => '',
+        'frequency' => 'Quotidiennement les jours ouvrables',
     ],
     'switzerland' => [
         'frequency' => 'Jour ouvrable à 11h00 heure d\'Europe centrale (CET)',
     ],
     'turkey' => [
-        'frequency' => '',
+        'frequency' => 'Quotidiennement les jours ouvrables',
     ],
     'ukraine' => [
-        'frequency' => '',
+        'frequency' => 'Quotidiennement les jours ouvrables',
     ],
 ];

--- a/resources/langs/pl/description.php
+++ b/resources/langs/pl/description.php
@@ -2,46 +2,49 @@
 
 return [
     'albania' => [
-        'frequency' => '',
+        'frequency' => 'Codziennie w dni robocze',
     ],
     'armenia' => [
-        'frequency' => '',
+        'frequency' => 'Codziennie w dni robocze',
     ],
     'australia' => [
         'frequency' => 'W dni powszednie około 16:00 czasu wschodnioaustralijskiego',
     ],
+    'azerbaijan' => [
+        'frequency' => 'Codziennie w dni robocze',
+    ],
     'bceao' => [
-        'frequency' => '',
+        'frequency' => 'Codziennie w dni robocze',
     ],
     'belarus' => [
-        'frequency' => '',
+        'frequency' => 'Codziennie w dni robocze',
     ],
     'bosnia-and-herzegovina' => [
-        'frequency' => '',
+        'frequency' => 'Codziennie w dni robocze',
     ],
     'botswana' => [
-        'frequency' => '',
+        'frequency' => 'Codziennie w dni robocze',
     ],
     'bulgaria' => [
-        'frequency' => '',
+        'frequency' => 'Codziennie w dni robocze',
     ],
     'canada' => [
-        'frequency' => '',
+        'frequency' => 'Codziennie w dni robocze',
     ],
     'china' => [
-        'frequency' => '',
+        'frequency' => 'Codziennie w dni robocze',
     ],
     'croatia' => [
-        'frequency' => '',
+        'frequency' => 'Codziennie w dni robocze',
     ],
     'czech-republic' => [
-        'frequency' => '',
+        'frequency' => 'Codziennie w dni robocze',
     ],
     'denmark' => [
-        'frequency' => '',
+        'frequency' => 'Codziennie w dni robocze',
     ],
     'england' => [
-        'frequency' => '',
+        'frequency' => 'Codziennie w dni robocze',
     ],
     'european-central-bank' => [
         'frequency' => 'Dzień powszedni o 15:00 czasu środkowoeuropejskiego (CET)',
@@ -55,25 +58,25 @@ return [
             'walut w stosunku do FJD.',
     ],
     'georgia' => [
-        'frequency' => '',
+        'frequency' => 'Codziennie w dni robocze',
     ],
     'hungary' => [
-        'frequency' => '',
+        'frequency' => 'Codziennie w dni robocze',
     ],
     'iceland' => [
-        'frequency' => '',
+        'frequency' => 'Codziennie w dni robocze',
     ],
     'israel' => [
-        'frequency' => '',
+        'frequency' => 'Codziennie w dni robocze',
     ],
     'macedonia' => [
-        'frequency' => '',
+        'frequency' => 'Codziennie w dni robocze',
     ],
     'moldavia' => [
-        'frequency' => '',
+        'frequency' => 'Codziennie w dni robocze',
     ],
     'norway' => [
-        'frequency' => '',
+        'frequency' => 'Codziennie w dni robocze',
     ],
     'poland' => [
         'frequency' => 'Tabela A kursów średnich walut obcych publikowana (aktualizowana) jest na stronie ' .
@@ -83,25 +86,25 @@ return [
             'rozliczeniowych aktualizowane są w każdy dzień roboczy, między godziną 7:45 a 8:15.',
     ],
     'romania' => [
-        'frequency' => '',
+        'frequency' => 'Codziennie w dni robocze',
     ],
     'russia' => [
-        'frequency' => '',
+        'frequency' => 'Codziennie w dni robocze',
     ],
     'serbia' => [
         'frequency' => 'Dzień powszedni o 8:00 czasu środkowoeuropejskiego (CET). W weekendy i święta wykaz ' .
             'kursów walut z ostatniego dnia roboczego.',
     ],
     'sweden' => [
-        'frequency' => '',
+        'frequency' => 'Codziennie w dni robocze',
     ],
     'switzerland' => [
         'frequency' => 'Dzień powszedni o 11:00 czasu środkowoeuropejskiego (CET)',
     ],
     'turkey' => [
-        'frequency' => '',
+        'frequency' => 'Codziennie w dni robocze',
     ],
     'ukraine' => [
-        'frequency' => '',
+        'frequency' => 'Codziennie w dni robocze',
     ],
 ];


### PR DESCRIPTION
## Summary
- document driver update frequencies in translations
- list driver frequencies in README

## Testing
- `composer test` *(fails: ArmeniaDriverTest, HungaryDriverTest, ChinaDriverTest, GeorgiaDriverTest, BceaoDriverTest, BelarusDriverTest, BotswanaDriverTest)*

------
https://chatgpt.com/codex/tasks/task_e_68a5cf2e32ec8333970bd5688be15bee