### PR TITLE
Add Redis cache store option and factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,12 +69,17 @@ return [
     ],
     'table-name' => env('FLEXMIND_CURRENCY_RATE_TABLENAME', 'currency_rates'),
     'cache-ttl' => env('FLEXMIND_CURRENCY_RATE_CACHE_TTL', 3600),
+    'cache_store' => env('FLEXMIND_CURRENCY_RATE_CACHE_STORE', 'array'),
 ];
 ```
 
 The `drivers` array defines which currency rate providers are available when running
 the command with `--driver=all`. Add or remove entries from this list to customise
 the drivers used in your application. See [config/currency-rate.php](config/currency-rate.php) for additional configuration options, including the cache TTL for HTTP requests.
+
+### Redis cache store
+
+To cache HTTP responses in Redis, set the `FLEXMIND_CURRENCY_RATE_CACHE_STORE` environment variable to `redis` and configure your Redis connection in the application's `database.redis` configuration.
 
 ### Available Drivers
 

--- a/config/currency-rate.php
+++ b/config/currency-rate.php
@@ -42,6 +42,8 @@ return [
 
     'cache-ttl' => env('FLEXMIND_CURRENCY_RATE_CACHE_TTL', 3600),
 
+    'cache_store' => env('FLEXMIND_CURRENCY_RATE_CACHE_STORE', 'array'),
+
     'retry' => [
         'count'  => (int) env('FLEXMIND_CURRENCY_RATE_RETRY_COUNT', 3), 
         'sleep'  => (int) env('FLEXMIND_CURRENCY_RATE_RETRY_SLEEP', 1000),

--- a/src/Drivers/HttpFetcher.php
+++ b/src/Drivers/HttpFetcher.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace FlexMindSoftware\CurrencyRate\Drivers;
 
 use GuzzleHttp\Psr7\Request;
-use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
+use FlexMindSoftware\CurrencyRate\Support\CacheFactory;
 use Psr\Http\Client\ClientInterface;
 use SimpleXMLElement;
 use Throwable;
@@ -29,8 +29,10 @@ trait HttpFetcher
         ksort($query);
         $key = 'currency-rate:' . $url . (empty($query) ? '' : '?' . http_build_query($query));
 
-        if (Cache::has($key)) {
-            return Cache::get($key);
+        $cache = CacheFactory::make();
+
+        if ($cache->has($key)) {
+            return $cache->get($key);
         }
 
         // --- RETRY CONFIG
@@ -66,7 +68,7 @@ trait HttpFetcher
                 }
 
                 if ($body !== null) {
-                    Cache::put($key, $body, config('currency-rate.cache-ttl'));
+                    $cache->put($key, $body, (int) config('currency-rate.cache-ttl'));
 
                     return $body;
                 }

--- a/src/Support/CacheFactory.php
+++ b/src/Support/CacheFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlexMindSoftware\CurrencyRate\Support;
+
+use Illuminate\Cache\Repository as CacheRepository;
+use Illuminate\Cache\RedisStore;
+use Illuminate\Contracts\Cache\Repository;
+use Illuminate\Contracts\Redis\Factory as RedisFactory;
+use Illuminate\Support\Facades\Cache;
+
+class CacheFactory
+{
+    public static function make(?string $store = null): Repository
+    {
+        $store = $store ?? (string) config('currency-rate.cache_store', 'array');
+
+        if ($store === 'redis') {
+            /** @var RedisFactory $redis */
+            $redis = app(RedisFactory::class);
+
+            return new CacheRepository(
+                new RedisStore($redis, (string) config('cache.prefix', ''))
+            );
+        }
+
+        return Cache::store($store);
+    }
+}

--- a/tests/RedisCacheTest.php
+++ b/tests/RedisCacheTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlexMindSoftware\CurrencyRate\Tests;
+
+use FlexMindSoftware\CurrencyRate\Drivers\HttpFetcher;
+use Illuminate\Contracts\Redis\Factory as RedisFactory;
+use Illuminate\Support\Facades\Http;
+
+class RedisCacheTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        config()->set('currency-rate.cache_store', 'redis');
+        config()->set('currency-rate.cache-ttl', 123);
+    }
+
+    private function fetcher()
+    {
+        return new class () {
+            use HttpFetcher;
+
+            public function callFetch($url, $query = [])
+            {
+                return $this->fetch($url, $query);
+            }
+        };
+    }
+
+    /** @test */
+    public function it_caches_with_ttl_and_reads_from_redis(): void
+    {
+        $redis = new class implements RedisFactory {
+            public array $calls = [];
+            public array $data = [];
+
+            public function connection($name = null)
+            {
+                return new class ($this) {
+                    public function __construct(private $parent) {}
+
+                    public function setex($key, $seconds, $value)
+                    {
+                        $this->parent->calls[] = [$key, $seconds, $value];
+                        $this->parent->data[$key] = $value;
+                        return true;
+                    }
+
+                    public function get($key)
+                    {
+                        return $this->parent->data[$key] ?? null;
+                    }
+                };
+            }
+        };
+
+        $this->app->instance(RedisFactory::class, $redis);
+
+        Http::fakeSequence()->push('redis-content', 200)->push('new-content', 200);
+
+        $fetcher = $this->fetcher();
+
+        $this->assertSame('redis-content', $fetcher->callFetch('https://example.com/test'));
+        $this->assertSame(123, $redis->calls[0][1]);
+
+        // Second call should hit cache and not trigger HTTP request
+        $this->assertSame('redis-content', $fetcher->callFetch('https://example.com/test'));
+        Http::assertSentCount(1);
+    }
+}


### PR DESCRIPTION
## Summary
- add configurable cache_store option with Redis support
- update HttpFetcher to honour cache store via CacheFactory
- document Redis cache configuration and add RedisCacheTest

## Testing
- `composer test` *(fails: BelarusDriverTest, BceaoDriverTest, ArmeniaDriverTest, ChinaDriverTest, GeorgiaDriverTest, HungaryDriverTest, BotswanaDriverTest)*

------
https://chatgpt.com/codex/tasks/task_e_68aefe7ea59483338b11a948f4fa1e50