### PR TITLE
Add audit log for rate changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,6 +413,10 @@ Please see [CHANGELOG](CHANGELOG.md) for more information on what has changed re
 
 Please see [CONTRIBUTING](.github/CONTRIBUTING.md) for details.
 
+## Audit Logs
+
+The package keeps track of rate changes in the `audit_logs` table. Each record stores the `currency_code`, previous and new rate (`old_rate`, `new_rate`) and the time of change (`changed_at`). This allows auditing modifications to currency rates over time.
+
 ### Adding new locales
 
 Translations for driver descriptions live in `resources/langs/{locale}/description.php`.

--- a/database/migrations/create_audit_logs_table.php.stub
+++ b/database/migrations/create_audit_logs_table.php.stub
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::create('audit_logs', function (Blueprint $table) {
+            $table->id();
+            $table->string('currency_code');
+            $table->float('old_rate', 12, 4)->nullable();
+            $table->float('new_rate', 12, 4);
+            $table->timestamp('changed_at');
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('audit_logs');
+    }
+};

--- a/src/Actions/StoreRate.php
+++ b/src/Actions/StoreRate.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlexMindSoftware\CurrencyRate\Actions;
+
+use FlexMindSoftware\CurrencyRate\Models\AuditLog;
+use FlexMindSoftware\CurrencyRate\Models\CurrencyRate;
+use Illuminate\Support\Carbon;
+
+class StoreRate
+{
+    public function execute(string $code, float $newRate): CurrencyRate
+    {
+        $currencyCode = strtoupper($code);
+        $currencyRate = CurrencyRate::where('code', $currencyCode)->first();
+        $oldRate = $currencyRate?->rate;
+
+        AuditLog::create([
+            'currency_code' => $currencyCode,
+            'old_rate' => $oldRate,
+            'new_rate' => $newRate,
+            'changed_at' => Carbon::now(),
+        ]);
+
+        if ($currencyRate) {
+            $currencyRate->rate = $newRate;
+            $currencyRate->save();
+
+            return $currencyRate;
+        }
+
+        return CurrencyRate::create([
+            'driver' => 'manual',
+            'code' => $currencyCode,
+            'date' => Carbon::now()->toDateString(),
+            'rate' => $newRate,
+            'multiplier' => 1,
+            'no' => null,
+        ]);
+    }
+}

--- a/src/Models/AuditLog.php
+++ b/src/Models/AuditLog.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlexMindSoftware\CurrencyRate\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class AuditLog extends Model
+{
+    public $timestamps = false;
+
+    protected $table = 'audit_logs';
+
+    protected $fillable = [
+        'currency_code',
+        'old_rate',
+        'new_rate',
+        'changed_at',
+    ];
+
+    protected $casts = [
+        'old_rate' => 'float',
+        'new_rate' => 'float',
+        'changed_at' => 'datetime',
+    ];
+}

--- a/tests/AuditLogTest.php
+++ b/tests/AuditLogTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlexMindSoftware\CurrencyRate\Tests;
+
+use FlexMindSoftware\CurrencyRate\Actions\StoreRate;
+use FlexMindSoftware\CurrencyRate\Models\CurrencyRate;
+
+class AuditLogTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        file_put_contents(__DIR__.'/../database/database.sqlite', '');
+        $currencyMigration = include __DIR__.'/../database/migrations/create_currency_rate_table.php.stub';
+        $currencyMigration->up();
+        $auditMigration = include __DIR__.'/../database/migrations/create_audit_logs_table.php.stub';
+        $auditMigration->up();
+    }
+
+    /** @test */
+    public function it_logs_rate_changes()
+    {
+        CurrencyRate::create([
+            'driver' => 'test',
+            'code' => 'USD',
+            'date' => now()->toDateString(),
+            'rate' => 1.0,
+            'multiplier' => 1,
+            'no' => null,
+        ]);
+
+        (new StoreRate())->execute('USD', 2.5);
+
+        $this->assertDatabaseHas('audit_logs', [
+            'currency_code' => 'USD',
+            'old_rate' => 1.0,
+            'new_rate' => 2.5,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- track rate changes in new `audit_logs` table
- log currency updates before saving
- document audit log purpose and structure

## Testing
- `vendor/bin/phpunit tests/AuditLogTest.php`
- `vendor/bin/phpunit` *(fails: TypeError in BceaoDriverTest, assertion failure in BotswanaDriverTest)*

------
https://chatgpt.com/codex/tasks/task_e_68af00a66440833398037c77868678cb