### PR TITLE
Expose currency rate API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,25 @@ Execute immediately without queueing:
 php artisan flexmind:currency-rate --queue=none
 ```
 
+## API
+
+Request the latest rate for a given currency code:
+
+```
+GET /api/currency-rate/{code}
+```
+
+Example response:
+
+```json
+{
+    "value": 4.5,
+    "date": "2023-10-01"
+}
+```
+
+If the currency code does not exist, the endpoint returns a `404` status.
+
 ## Testing
 
 ```bash

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,0 +1,6 @@
+<?php
+
+use FlexMindSoftware\CurrencyRate\Http\Controllers\CurrencyRateController;
+use Illuminate\Support\Facades\Route;
+
+Route::get('/api/currency-rate/{code}', [CurrencyRateController::class, 'show']);

--- a/src/CurrencyRateServiceProvider.php
+++ b/src/CurrencyRateServiceProvider.php
@@ -24,6 +24,7 @@ class CurrencyRateServiceProvider extends PackageServiceProvider
             ->name('currency-rate')
             ->hasConfigFile()
             ->hasTranslations()
+            ->hasRoute('api')
             ->hasMigration('create_currency_rate_table')
             ->hasCommand(CurrencyRateCommand::class);
     }

--- a/src/Http/Controllers/CurrencyRateController.php
+++ b/src/Http/Controllers/CurrencyRateController.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlexMindSoftware\CurrencyRate\Http\Controllers;
+
+use FlexMindSoftware\CurrencyRate\Models\CurrencyRate;
+use Illuminate\Http\JsonResponse;
+
+class CurrencyRateController
+{
+    public function show(string $code): JsonResponse
+    {
+        $rate = CurrencyRate::query()
+            ->where('code', strtoupper($code))
+            ->orderByDesc('date')
+            ->first();
+
+        if (! $rate) {
+            abort(404);
+        }
+
+        return response()->json([
+            'value' => $rate->calculate_rate,
+            'date' => $rate->date->toDateString(),
+        ]);
+    }
+}

--- a/tests/Http/CurrencyRateControllerTest.php
+++ b/tests/Http/CurrencyRateControllerTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlexMindSoftware\CurrencyRate\Tests\Http;
+
+use FlexMindSoftware\CurrencyRate\Models\CurrencyRate;
+use FlexMindSoftware\CurrencyRate\Tests\TestCase;
+
+class CurrencyRateControllerTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        file_put_contents(__DIR__.'/../../database/database.sqlite', '');
+        $migration = include __DIR__.'/../../database/migrations/create_currency_rate_table.php.stub';
+        $migration->up();
+    }
+
+    /** @test */
+    public function it_returns_rate_and_date(): void
+    {
+        CurrencyRate::create([
+            'driver' => 'test',
+            'code' => 'USD',
+            'date' => '2023-10-01',
+            'rate' => 4.5,
+            'multiplier' => 1,
+        ]);
+
+        $this->getJson('/api/currency-rate/USD')
+            ->assertStatus(200)
+            ->assertExactJson([
+                'value' => 4.5,
+                'date' => '2023-10-01',
+            ]);
+    }
+
+    /** @test */
+    public function it_returns_404_for_unknown_code(): void
+    {
+        $this->getJson('/api/currency-rate/XYZ')->assertStatus(404);
+    }
+}


### PR DESCRIPTION
## Summary
- add `/api/currency-rate/{code}` route and controller returning latest rate
- document new API endpoint
- cover currency rate controller with tests

## Testing
- `composer test` *(fails: BceaoDriverTest, ChinaDriverTest, BelarusDriverTest, BotswanaDriverTest, ArmeniaDriverTest, HungaryDriverTest, GeorgiaDriverTest)*

------
https://chatgpt.com/codex/tasks/task_e_68af00b9b1ac8333b46ad87ed9d57f82