### PR TITLE
Add Spanish localization and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,7 @@ Please see [CONTRIBUTING](.github/CONTRIBUTING.md) for details.
 ### Adding new locales
 
 Translations for driver descriptions live in `resources/langs/{locale}/description.php`.
+Currently supported locales: `en`, `es`, `fr`, `pl`.
 To contribute a new locale:
 
 1. Create a new directory for the locale under `resources/langs` (for example `es` for Spanish).

--- a/resources/lang/es/description.php
+++ b/resources/lang/es/description.php
@@ -1,0 +1,111 @@
+<?php
+
+return [
+    'albania' => [
+        'frequency' => 'Diariamente en días laborables',
+    ],
+    'armenia' => [
+        'frequency' => 'Diariamente en días laborables',
+    ],
+    'australia' => [
+        'frequency' => 'Días laborables alrededor de las 16:00 hora del este de Australia',
+    ],
+    'azerbaijan' => [
+        'frequency' => 'Diariamente en días laborables',
+    ],
+    'bceao' => [
+        'frequency' => 'Diariamente en días laborables',
+    ],
+    'belarus' => [
+        'frequency' => 'Diariamente en días laborables',
+    ],
+    'bosnia-and-herzegovina' => [
+        'frequency' => 'Diariamente en días laborables',
+    ],
+    'botswana' => [
+        'frequency' => 'Diariamente en días laborables',
+    ],
+    'bulgaria' => [
+        'frequency' => 'Diariamente en días laborables',
+    ],
+    'canada' => [
+        'frequency' => 'Diariamente en días laborables',
+    ],
+    'china' => [
+        'frequency' => 'Diariamente en días laborables',
+    ],
+    'croatia' => [
+        'frequency' => 'Diariamente en días laborables',
+    ],
+    'czech-republic' => [
+        'frequency' => 'Diariamente en días laborables',
+    ],
+    'denmark' => [
+        'frequency' => 'Diariamente en días laborables',
+    ],
+    'england' => [
+        'frequency' => 'Diariamente en días laborables',
+    ],
+    'european-central-bank' => [
+        'frequency' => 'Día laborable a las 15:00 hora de Europa Central (CET)',
+    ],
+    'fiji' => [
+        'frequency' => 'Fiyi tiene un sistema de tipo de cambio fijo donde el dólar fiyiano (FJD) está vinculado a una ' .
+            'cesta ponderada de monedas que comprende el dólar australiano (AUD), el dólar neozelandés (NZD), ' .
+            'el dólar estadounidense (USD), el yen japonés (JPY) y el euro (EUR). La tasa publicada para el ' .
+            'FJD-USD es la tasa oficial que se fija a las 8:30 a.m. cada día hábil por el Banco de la Reserva. ' .
+            'Esta tasa se utiliza para calcular las tasas del AUD, NZD, JPY, EUR y otras ' .
+            'monedas frente al FJD.',
+    ],
+    'georgia' => [
+        'frequency' => 'Diariamente en días laborables',
+    ],
+    'hungary' => [
+        'frequency' => 'Diariamente en días laborables',
+    ],
+    'iceland' => [
+        'frequency' => 'Diariamente en días laborables',
+    ],
+    'israel' => [
+        'frequency' => 'Diariamente en días laborables',
+    ],
+    'macedonia' => [
+        'frequency' => 'Diariamente en días laborables',
+    ],
+    'moldavia' => [
+        'frequency' => 'Diariamente en días laborables',
+    ],
+    'norway' => [
+        'frequency' => 'Diariamente en días laborables',
+    ],
+    'poland' => [
+        'frequency' => 'La Tabla A de los tipos de cambio medios de divisas se publica (actualiza) en el sitio web del NBP ' .
+            'en días laborables entre las 11:45 a.m. y las 12:15 p.m., la Tabla B de los tipos de cambio medios ' .
+            'de divisas se publica (actualiza) en el sitio web del NBP los miércoles entre las 11:45 a.m. y las ' .
+            '12:15 p.m., la Tabla C de los tipos de cambio de compra y venta de divisas y la tabla de tipos de ' .
+            'unidades de cuenta se publican (actualizan) en el sitio web del NBP en días laborables entre las ' .
+            '7:45 a.m. y las 8:15 a.m.',
+    ],
+    'romania' => [
+        'frequency' => 'Diariamente en días laborables',
+    ],
+    'russia' => [
+        'frequency' => 'Diariamente en días laborables',
+    ],
+    'serbia' => [
+        'frequency' => 'Día laborable a las 8:00 CET. En fines de semana y días festivos, una lista de tipos de cambio ' .
+            'del último día laborable',
+    ],
+    'sweden' => [
+        'frequency' => 'Diariamente en días laborables',
+    ],
+    'switzerland' => [
+        'frequency' => 'Día laborable a las 11:00 AM hora de Europa Central (CET)',
+    ],
+    'turkey' => [
+        'frequency' => 'Diariamente en días laborables',
+    ],
+    'ukraine' => [
+        'frequency' => 'Diariamente en días laborables',
+    ],
+];

--- a/tests/LangEsTest.php
+++ b/tests/LangEsTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlexMindSoftware\CurrencyRate\Tests;
+
+class LangEsTest extends TestCase
+{
+    /** @test */
+    public function it_loads_spanish_translations(): void
+    {
+        app()->setLocale('es');
+
+        $this->assertSame(
+            'Diariamente en días laborables',
+            __('currency-rate::description.albania.frequency')
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add Spanish localization file under `resources/lang/es`
- document `es` support in README
- cover Spanish locale loading with test

## Testing
- `composer test` *(fails: BceaoDriverTest, GeorgiaDriverTest, ArmeniaDriverTest, BotswanaDriverTest, BelarusDriverTest, ChinaDriverTest, HungaryDriverTest)*

------
https://chatgpt.com/codex/tasks/task_e_68af00db5ee08333b7a493ae0b5f0f90