### PR TITLE
Add United States currency driver using FRED API

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,14 @@ return [
         'switzerland',
         'turkey',
         'ukraine',
+        'united-states',
     ],
     'table-name' => env('FLEXMIND_CURRENCY_RATE_TABLENAME', 'currency_rates'),
     'cache-ttl' => env('FLEXMIND_CURRENCY_RATE_CACHE_TTL', 3600),
     'cache_store' => env('FLEXMIND_CURRENCY_RATE_CACHE_STORE', 'array'),
+    'fed' => [
+        'api_key' => env('FRED_API_KEY'),
+    ],
 ];
 ```
 
@@ -117,6 +121,7 @@ To cache HTTP responses in Redis, set the `FLEXMIND_CURRENCY_RATE_CACHE_STORE` e
 | Switzerland | `switzerland` | Weekdays at 11:00 AM CET |
 | Turkey | `turkey` | Daily on business days |
 | Ukraine | `ukraine` | Daily on business days |
+| United States | `united-states` | Daily on business days |
 
 ## Usage
 
@@ -160,7 +165,7 @@ php artisan flexmind:currency-rate 2023-09-15
 Use a specific driver:
 
 ```bash
-php artisan flexmind:currency-rate --driver=canada
+php artisan flexmind:currency-rate --driver=united-states
 ```
 
 Dispatch the job to a queue:

--- a/config/currency-rate.php
+++ b/config/currency-rate.php
@@ -36,6 +36,7 @@ return [
         'switzerland',
         'turkey',
         'ukraine',
+        'united-states',
     ],
 
     'table-name' => env('FLEXMIND_CURRENCY_RATE_TABLENAME', 'currency_rates'),
@@ -43,6 +44,10 @@ return [
     'cache-ttl' => env('FLEXMIND_CURRENCY_RATE_CACHE_TTL', 3600),
 
     'cache_store' => env('FLEXMIND_CURRENCY_RATE_CACHE_STORE', 'array'),
+
+    'fed' => [
+        'api_key' => env('FRED_API_KEY'),
+    ],
 
     'retry' => [
         'count'  => (int) env('FLEXMIND_CURRENCY_RATE_RETRY_COUNT', 3), 

--- a/resources/langs/en/description.php
+++ b/resources/langs/en/description.php
@@ -108,4 +108,7 @@ return [
     'ukraine' => [
         'frequency' => 'Daily on business days',
     ],
+    'united-states' => [
+        'frequency' => 'Daily on business days',
+    ],
 ];

--- a/resources/langs/es/description.php
+++ b/resources/langs/es/description.php
@@ -108,4 +108,7 @@ return [
     'ukraine' => [
         'frequency' => 'Diariamente en días laborables',
     ],
+    'united-states' => [
+        'frequency' => 'Diariamente en días laborables',
+    ],
 ];

--- a/resources/langs/fr/description.php
+++ b/resources/langs/fr/description.php
@@ -107,4 +107,7 @@ return [
     'ukraine' => [
         'frequency' => 'Quotidiennement les jours ouvrables',
     ],
+    'united-states' => [
+        'frequency' => 'Quotidiennement les jours ouvrables',
+    ],
 ];

--- a/resources/langs/pl/description.php
+++ b/resources/langs/pl/description.php
@@ -107,4 +107,7 @@ return [
     'ukraine' => [
         'frequency' => 'Codziennie w dni robocze',
     ],
+    'united-states' => [
+        'frequency' => 'Codziennie w dni robocze',
+    ],
 ];

--- a/src/CurrencyRateServiceProvider.php
+++ b/src/CurrencyRateServiceProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace FlexMindSoftware\CurrencyRate;
 
 use FlexMindSoftware\CurrencyRate\Commands\CurrencyRateCommand;
+use FlexMindSoftware\CurrencyRate\Drivers\UnitedStatesDriver;
 use InvalidArgumentException;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
@@ -38,6 +39,8 @@ class CurrencyRateServiceProvider extends PackageServiceProvider
         $this->app->singleton('currency-rate', function ($app) {
             return new CurrencyRateManager($app);
         });
+
+        $this->app->bind(UnitedStatesDriver::class, fn ($app) => new UnitedStatesDriver());
     }
 
     protected function validateConfig(): void

--- a/src/Drivers/BaseDriver.php
+++ b/src/Drivers/BaseDriver.php
@@ -163,9 +163,9 @@ abstract class BaseDriver implements DriverMetadata
      *
      * @return float
      */
-    protected function stringToFloat(string $string): float
+    protected function stringToFloat(int|float|string $string): float
     {
-        return (float)str_replace(',', '.', $string);
+        return (float) str_replace(',', '.', (string) $string);
     }
 
     /**

--- a/src/Drivers/BelarusDriver.php
+++ b/src/Drivers/BelarusDriver.php
@@ -68,16 +68,16 @@ class BelarusDriver extends BaseDriver implements CurrencyInterface
         $xml = $this->parseXml($this->xml);
 
         if (count($xml->Currency)) {
-            $date = DateTimeImmutable::createFromFormat('m/d/Y', $xml->attributes()[0])->format('Y-m-d');
+            $date = DateTimeImmutable::createFromFormat('m/d/Y', (string) $xml->attributes()[0])->format('Y-m-d');
 
             foreach ($xml->Currency as $xmlElement) {
                 $this->data[] = [
-                    'no' => (int)$xmlElement->attributes()[0],
+                    'no' => (string) $xmlElement->attributes()[0],
                     'code' => (string)$xmlElement->CharCode,
                     'date' => $date,
                     'driver' => static::DRIVER_NAME,
-                    'multiplier' => $this->stringToFloat((int)$xmlElement->Scale),
-                    'rate' => $this->stringToFloat($xmlElement->Rate),
+                    'multiplier' => $this->stringToFloat((string) $xmlElement->Scale),
+                    'rate' => $this->stringToFloat((string) $xmlElement->Rate),
                 ];
             }
         }

--- a/src/Drivers/HungaryDriver.php
+++ b/src/Drivers/HungaryDriver.php
@@ -6,6 +6,7 @@ namespace FlexMindSoftware\CurrencyRate\Drivers;
 
 use DOMDocument;
 use DOMXPath;
+use DateTimeImmutable;
 use FlexMindSoftware\CurrencyRate\Contracts\CurrencyInterface;
 use FlexMindSoftware\CurrencyRate\Enums\CurrencyCode;
 use FlexMindSoftware\CurrencyRate\Models\RateTrait;
@@ -101,8 +102,8 @@ class HungaryDriver extends BaseDriver implements CurrencyInterface
             foreach ($row as $i => $item) {
                 if ($item != '-') {
                     $line = $currencies[$i];
-                    $line['date'] = date('Y-m-d', strtotime($date));
-                    $line['rate'] = (float)$item;
+                    $line['date'] = DateTimeImmutable::createFromFormat('Y.m.d.', $date)->format('Y-m-d');
+                    $line['rate'] = (float) $item;
 
                     $this->data[] = $line;
                 }

--- a/src/Drivers/HungaryDriver.php
+++ b/src/Drivers/HungaryDriver.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace FlexMindSoftware\CurrencyRate\Drivers;
 
+use DateTimeImmutable;
 use DOMDocument;
 use DOMXPath;
-use DateTimeImmutable;
 use FlexMindSoftware\CurrencyRate\Contracts\CurrencyInterface;
 use FlexMindSoftware\CurrencyRate\Enums\CurrencyCode;
 use FlexMindSoftware\CurrencyRate\Models\RateTrait;

--- a/src/Drivers/UnitedStatesDriver.php
+++ b/src/Drivers/UnitedStatesDriver.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlexMindSoftware\CurrencyRate\Drivers;
+
+use FlexMindSoftware\CurrencyRate\Contracts\CurrencyInterface;
+use FlexMindSoftware\CurrencyRate\Enums\CurrencyCode;
+use FlexMindSoftware\CurrencyRate\Models\RateTrait;
+
+class UnitedStatesDriver extends BaseDriver implements CurrencyInterface
+{
+    use RateTrait;
+
+    public const URI = 'https://api.stlouisfed.org/fred/series/observations';
+
+    public const DRIVER_NAME = 'united-states';
+
+    /**
+     * @var CurrencyCode
+     */
+    public CurrencyCode $currency = CurrencyCode::USD;
+
+    /**
+     * Map ISO currency codes to FRED series identifiers.
+     *
+     * @var array<string, string>
+     */
+    protected const SERIES_MAP = [
+        'EUR' => 'DEXUSEU',
+        'GBP' => 'DEXUSUK',
+    ];
+
+    /**
+     * @return self
+     */
+    public function grabExchangeRates(): self
+    {
+        $this->data = [];
+        $date = $this->date->format('Y-m-d');
+
+        foreach (self::SERIES_MAP as $code => $series) {
+            $query = array_filter([
+                'series_id' => $series,
+                'observation_start' => $date,
+                'observation_end' => $date,
+                'file_type' => 'json',
+                'api_key' => $this->config['fed']['api_key'] ?? null,
+            ]);
+
+            $response = $this->fetch(self::URI, $query);
+            if ($response) {
+                $json = json_decode($response, true);
+                $value = $json['observations'][0]['value'] ?? null;
+
+                if ($value && $value !== '.') {
+                    $rate = (float) $value;
+                    if ($rate > 0) {
+                        $this->data[] = [
+                            'no' => null,
+                            'code' => $code,
+                            'driver' => self::DRIVER_NAME,
+                            'date' => $date,
+                            'multiplier' => 1,
+                            'rate' => 1 / $rate,
+                        ];
+                    }
+                }
+            }
+        }
+
+        return $this;
+    }
+
+    public function fullName(): string
+    {
+        return 'Federal Reserve Bank of St. Louis';
+    }
+
+    public function homeUrl(): string
+    {
+        return 'https://fred.stlouisfed.org/';
+    }
+
+    public function infoAboutFrequency(): string
+    {
+        return __('currency-rate::description.united-states.frequency');
+    }
+}

--- a/tests/Drivers/UnitedStatesDriverTest.php
+++ b/tests/Drivers/UnitedStatesDriverTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlexMindSoftware\CurrencyRate\Tests\Drivers;
+
+use DateTimeImmutable;
+use FlexMindSoftware\CurrencyRate\Drivers\UnitedStatesDriver;
+use FlexMindSoftware\CurrencyRate\Tests\TestCase;
+
+class UnitedStatesDriverTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+        file_put_contents(__DIR__.'/../../database/database.sqlite', '');
+        $migration = include __DIR__.'/../../database/migrations/create_currency_rate_table.php.stub';
+        $migration->up();
+    }
+
+    /** @test */
+    public function it_parses_united_states_response()
+    {
+        $driver = (new class () extends UnitedStatesDriver {
+            protected function fetch(string $url, array $query = []): ?string
+            {
+                return match ($query['series_id'] ?? '') {
+                    'DEXUSEU' => file_get_contents(__DIR__.'/../Fixtures/united_states_eur.json'),
+                    'DEXUSUK' => file_get_contents(__DIR__.'/../Fixtures/united_states_gbp.json'),
+                    default => null,
+                };
+            }
+        })->setDataTime(new DateTimeImmutable('2021-09-24'));
+
+        $driver->grabExchangeRates();
+        $data = $driver->retrieveData();
+
+        $eur = collect($data)->firstWhere('code', 'EUR');
+        $gbp = collect($data)->firstWhere('code', 'GBP');
+
+        $this->assertNotNull($eur);
+        $this->assertSame('EUR', $eur->code);
+        $this->assertEquals(1, $eur->multiplier);
+        $this->assertEquals(0.5, $eur->rate);
+
+        $this->assertNotNull($gbp);
+        $this->assertSame('GBP', $gbp->code);
+        $this->assertEquals(1, $gbp->multiplier);
+        $this->assertEquals(0.25, $gbp->rate);
+    }
+}

--- a/tests/Fixtures/united_states_eur.json
+++ b/tests/Fixtures/united_states_eur.json
@@ -1,0 +1,1 @@
+{"observations":[{"date":"2021-09-24","value":"2"}]}

--- a/tests/Fixtures/united_states_gbp.json
+++ b/tests/Fixtures/united_states_gbp.json
@@ -1,0 +1,1 @@
+{"observations":[{"date":"2021-09-24","value":"4"}]}


### PR DESCRIPTION
## Summary
- add UnitedStatesDriver with FRED API endpoint and currency mappings
- expose `united-states` driver in config and service provider
- document and test new driver; update translations
- improve numeric parsing and date handling in base and existing drivers

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68af00ca7fd8833395fa515d09d33af2