### PR TITLE
Add currency filter option to download command

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Arguments:
 Options:
   --queue[=QUEUE]    Queue name, if set "none" cmd run without add job to queue [default: "none"]
   --driver[=DRIVER]  Driver to download rate [default: "all"]
+  --currency[=CUR]   Comma-separated list of currency codes to save
 ```
 
 ## Events

--- a/src/Commands/DownloadCommand.php
+++ b/src/Commands/DownloadCommand.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlexMindSoftware\CurrencyRate\Commands;
+
+use DateTimeImmutable;
+use FlexMindSoftware\CurrencyRate\CurrencyRateFacade as CurrencyRate;
+use FlexMindSoftware\CurrencyRate\Jobs\QueueDownload;
+use FlexMindSoftware\CurrencyRate\Models\CurrencyRate as CurrencyRateModel;
+use Illuminate\Console\Command;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+/**
+ * php artisan flexmind:currency-rate:download --driver=
+ */
+class DownloadCommand extends Command
+{
+    public $signature = 'flexmind:currency-rate:download
+        {date? : Date to download currency rate, if empty is today}
+        {--queue=none : Queue name, if set "none" cmd run without add job to queue};
+        {--connection=default : The database connection to use};
+        {--driver=all : Driver to download rate};
+        {--currency= : Comma separated list of currency codes to save}';
+
+    public $description = 'Download and save into database currency rates from different national bank';
+
+    /**
+     * @return int
+     */
+    public function handle(): int
+    {
+        $currencyDate = $this->argument('date');
+        $timestamp = is_string($currencyDate) && $currencyDate !== '' ? strtotime($currencyDate) ?: time() : time();
+
+        $queueOption = $this->option('queue');
+        $queue = is_string($queueOption) ? $queueOption : 'none';
+        $driverOption = $this->option('driver');
+        $driver = $driverOption ?? 'all';
+        $connectionOption = $this->option('connection');
+        $connection = is_string($connectionOption) ? $connectionOption : 'default';
+
+        $currencyOption = $this->option('currency');
+        $currencies = [];
+        if (is_array($currencyOption)) {
+            $currencies = $currencyOption;
+        } elseif (is_string($currencyOption) && $currencyOption !== '') {
+            $currencies = array_map('trim', explode(',', $currencyOption));
+        }
+        $currencies = array_filter($currencies);
+
+        if ($driver === 'all') {
+            $driver = $this->getAllDrivers();
+        } elseif ($driver === 'default') {
+            $driver = Arr::wrap(config('currency-rate.driver'));
+        }
+
+        $drivers = Arr::wrap($driver);
+        $drivers = array_filter($drivers);
+        $date = new DateTimeImmutable("@$timestamp");
+
+        foreach ($drivers as $driver) {
+            if ($queue === 'none') {
+                $this->processDriver($driver, $date, $connection, $currencies);
+            } else {
+                $this->queueDriver($driver, $date, $connection, $queue);
+            }
+        }
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * @param string $driver
+     * @param DateTimeImmutable $date
+     * @param string|null $connection
+     * @param array<int, string> $currencies
+     */
+    private function processDriver(string $driver, DateTimeImmutable $date, ?string $connection, array $currencies): void
+    {
+        try {
+            $data = CurrencyRate::driver($driver)
+                ->setDataTime($date)
+                ->grabExchangeRates()
+                ->retrieveData();
+
+            if ($currencies !== []) {
+                $data = array_filter($data, fn ($item) => in_array($item->code, $currencies, true));
+            }
+
+            if ($data && $connection) {
+                $this->saveInDatabase($data, $connection);
+            }
+        } catch (Throwable $exception) {
+            Log::error(
+                'Can\\t grab data from [' . $driver . ']: ' . $exception->getMessage(),
+                $exception->getTrace()
+            );
+        }
+    }
+
+    private function queueDriver(string $driver, DateTimeImmutable $date, ?string $connection, string $queue): void
+    {
+        QueueDownload::dispatch($driver, $date, $connection)->onQueue($queue);
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function getAllDrivers(): array
+    {
+        $drivers = config('currency-rate.drivers', []);
+        sort($drivers);
+
+        return $drivers;
+    }
+
+    /**
+     * @param array<int, mixed> $data
+     */
+    private function saveInDatabase(array $data, string $connection): void
+    {
+        if ($data) {
+            CurrencyRateModel::saveIn($data, $connection);
+        }
+    }
+}

--- a/src/CurrencyRateServiceProvider.php
+++ b/src/CurrencyRateServiceProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace FlexMindSoftware\CurrencyRate;
 
 use FlexMindSoftware\CurrencyRate\Commands\CurrencyRateCommand;
+use FlexMindSoftware\CurrencyRate\Commands\DownloadCommand;
 use FlexMindSoftware\CurrencyRate\Drivers\UnitedStatesDriver;
 use InvalidArgumentException;
 use Spatie\LaravelPackageTools\Package;
@@ -27,7 +28,8 @@ class CurrencyRateServiceProvider extends PackageServiceProvider
             ->hasTranslations()
             ->hasRoute('api')
             ->hasMigration('create_currency_rate_table')
-            ->hasCommand(CurrencyRateCommand::class);
+            ->hasCommand(CurrencyRateCommand::class)
+            ->hasCommand(DownloadCommand::class);
     }
 
     /**

--- a/tests/Commands/DownloadCommandFilterTest.php
+++ b/tests/Commands/DownloadCommandFilterTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlexMindSoftware\CurrencyRate\Tests\Commands;
+
+use FlexMindSoftware\CurrencyRate\Contracts\CurrencyInterface;
+use FlexMindSoftware\CurrencyRate\CurrencyRateFacade as CurrencyRate;
+use FlexMindSoftware\CurrencyRate\Drivers\BaseDriver;
+use FlexMindSoftware\CurrencyRate\DTO\CurrencyRateData;
+use FlexMindSoftware\CurrencyRate\Enums\CurrencyCode;
+use FlexMindSoftware\CurrencyRate\Models\RateTrait;
+use FlexMindSoftware\CurrencyRate\Tests\TestCase;
+use Illuminate\Support\Facades\Http;
+
+class DownloadCommandFilterTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+        file_put_contents(__DIR__.'/../../database/database.sqlite', '');
+        $migration = include __DIR__.'/../../database/migrations/create_currency_rate_table.php.stub';
+        $migration->up();
+        CurrencyRate::extend(FakeMultiDriver::DRIVER_NAME, fn () => new FakeMultiDriver());
+    }
+
+    /** @test */
+    public function it_saves_only_specified_currencies(): void
+    {
+        Http::fake([
+            'example.com/*' => Http::response('ok', 200),
+        ]);
+
+        $this->artisan('flexmind:currency-rate:download', [
+            'date' => '2023-10-01',
+            '--driver' => FakeMultiDriver::DRIVER_NAME,
+            '--queue' => 'none',
+            '--connection' => 'testing',
+            '--currency' => 'GBP',
+        ])->assertExitCode(0);
+
+        $this->assertDatabaseHas('currency_rates', ['code' => 'GBP']);
+        $this->assertDatabaseMissing('currency_rates', ['code' => 'USD']);
+    }
+}
+
+class FakeMultiDriver extends BaseDriver implements CurrencyInterface
+{
+    use RateTrait;
+
+    public const DRIVER_NAME = 'fake-multi';
+    public const URI = 'https://example.com/rates';
+
+    public CurrencyCode $currency = CurrencyCode::EUR;
+
+    public function grabExchangeRates(): self
+    {
+        $this->fetch(static::URI);
+
+        $this->data[] = new CurrencyRateData(
+            driver: self::DRIVER_NAME,
+            code: 'USD',
+            date: '2023-10-01',
+            rate: 1.1,
+            multiplier: 1,
+            no: null,
+        );
+
+        $this->data[] = new CurrencyRateData(
+            driver: self::DRIVER_NAME,
+            code: 'GBP',
+            date: '2023-10-01',
+            rate: 1.2,
+            multiplier: 1,
+            no: null,
+        );
+
+        return $this;
+    }
+
+    public function fullName(): string
+    {
+        return 'Fake Multi Driver';
+    }
+
+    public function homeUrl(): string
+    {
+        return 'https://example.com';
+    }
+
+    public function infoAboutFrequency(): string
+    {
+        return '';
+    }
+}


### PR DESCRIPTION
## Summary
- add `--currency` option to download command
- document currency option in README
- test filtering currencies during download

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68af06f5e51c8333819849598070e521