### PR TITLE
Add configurable log channel with Logger wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ return [
     'table-name' => env('FLEXMIND_CURRENCY_RATE_TABLENAME', 'currency_rates'),
     'cache-ttl' => env('FLEXMIND_CURRENCY_RATE_CACHE_TTL', 3600),
     'cache_store' => env('FLEXMIND_CURRENCY_RATE_CACHE_STORE', 'array'),
+
+    'log_channel' => env('FLEXMIND_CURRENCY_RATE_LOG_CHANNEL', null),
     'fed' => [
         'api_key' => env('FRED_API_KEY'),
     ],
@@ -81,6 +83,8 @@ return [
 The `drivers` array defines which currency rate providers are available when running
 the command with `--driver=all`. Add or remove entries from this list to customise
 the drivers used in your application. See [config/currency-rate.php](config/currency-rate.php) for additional configuration options, including the cache TTL for HTTP requests and the `queue_concurrency` limit for queued jobs.
+
+Set the `log_channel` option (or the `FLEXMIND_CURRENCY_RATE_LOG_CHANNEL` environment variable) to direct package logs to a specific Laravel logging channel. If `null`, the application's default logging channel will be used.
 
 ### Redis cache store
 

--- a/config/currency-rate.php
+++ b/config/currency-rate.php
@@ -45,6 +45,8 @@ return [
 
     'cache_store' => env('FLEXMIND_CURRENCY_RATE_CACHE_STORE', 'array'),
 
+    'log_channel' => env('FLEXMIND_CURRENCY_RATE_LOG_CHANNEL', null),
+
     'fed' => [
         'api_key' => env('FRED_API_KEY'),
     ],

--- a/src/Commands/CurrencyRateCommand.php
+++ b/src/Commands/CurrencyRateCommand.php
@@ -11,7 +11,7 @@ use FlexMindSoftware\CurrencyRate\Models\CurrencyRate as CurrencyRateModel;
 use Illuminate\Console\Command;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Bus;
-use Illuminate\Support\Facades\Log;
+use FlexMindSoftware\CurrencyRate\Support\Logger;
 use Throwable;
 
 /**
@@ -84,7 +84,7 @@ class CurrencyRateCommand extends Command
                 $this->saveInDatabase($data, $connection);
             }
         } catch (Throwable $exception) {
-            Log::error(
+            Logger::error(
                 'Can\t grab data from [' . $driver . ']: ' . $exception->getMessage(),
                 $exception->getTrace()
             );

--- a/src/Commands/CurrencyRateCommand.php
+++ b/src/Commands/CurrencyRateCommand.php
@@ -8,10 +8,10 @@ use DateTimeImmutable;
 use FlexMindSoftware\CurrencyRate\CurrencyRateFacade as CurrencyRate;
 use FlexMindSoftware\CurrencyRate\Jobs\QueueDownload;
 use FlexMindSoftware\CurrencyRate\Models\CurrencyRate as CurrencyRateModel;
+use FlexMindSoftware\CurrencyRate\Support\Logger;
 use Illuminate\Console\Command;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Bus;
-use FlexMindSoftware\CurrencyRate\Support\Logger;
 use Throwable;
 
 /**

--- a/src/Drivers/BaseDriver.php
+++ b/src/Drivers/BaseDriver.php
@@ -11,7 +11,7 @@ use FlexMindSoftware\CurrencyRate\Contracts\DriverMetadata;
 use FlexMindSoftware\CurrencyRate\DTO\CurrencyRateData;
 use FlexMindSoftware\CurrencyRate\Models\CurrencyRate;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Log;
+use FlexMindSoftware\CurrencyRate\Support\Logger;
 use Psr\Http\Client\ClientInterface;
 
 abstract class BaseDriver implements DriverMetadata
@@ -142,7 +142,7 @@ abstract class BaseDriver implements DriverMetadata
                         CurrencyRate::upsert($mapped, $columns, ['rate', 'multiplier']);
                     });
                 } catch (\Throwable $e) {
-                    Log::error('CurrencyRate upsert failed', ['exception' => $e]);
+                    Logger::error('CurrencyRate upsert failed', ['exception' => $e]);
                 }
             }
         }

--- a/src/Drivers/BaseDriver.php
+++ b/src/Drivers/BaseDriver.php
@@ -10,8 +10,8 @@ use DOMXPath;
 use FlexMindSoftware\CurrencyRate\Contracts\DriverMetadata;
 use FlexMindSoftware\CurrencyRate\DTO\CurrencyRateData;
 use FlexMindSoftware\CurrencyRate\Models\CurrencyRate;
-use Illuminate\Support\Facades\DB;
 use FlexMindSoftware\CurrencyRate\Support\Logger;
+use Illuminate\Support\Facades\DB;
 use Psr\Http\Client\ClientInterface;
 
 abstract class BaseDriver implements DriverMetadata

--- a/src/Drivers/BotswanaDriver.php
+++ b/src/Drivers/BotswanaDriver.php
@@ -8,7 +8,7 @@ use DateTimeImmutable;
 use FlexMindSoftware\CurrencyRate\Contracts\CurrencyInterface;
 use FlexMindSoftware\CurrencyRate\Enums\CurrencyCode;
 use FlexMindSoftware\CurrencyRate\Models\RateTrait;
-use Illuminate\Support\Facades\Log;
+use FlexMindSoftware\CurrencyRate\Support\Logger;
 
 class BotswanaDriver extends BaseDriver implements CurrencyInterface
 {
@@ -44,7 +44,7 @@ class BotswanaDriver extends BaseDriver implements CurrencyInterface
                 $this->parseResponse();
             }
         } catch (\Throwable $e) {
-            Log::debug('Can\'t connect to serwer', $e->getTrace());
+            Logger::debug('Can\'t connect to serwer', $e->getTrace());
         }
 
         return $this;

--- a/src/Jobs/QueueDownload.php
+++ b/src/Jobs/QueueDownload.php
@@ -7,6 +7,7 @@ namespace FlexMindSoftware\CurrencyRate\Jobs;
 use DateTimeImmutable;
 use FlexMindSoftware\CurrencyRate\CurrencyRateFacade as CurrencyRate;
 use FlexMindSoftware\CurrencyRate\Models\CurrencyRate as CurrencyRateModel;
+use FlexMindSoftware\CurrencyRate\Support\Logger;
 use Illuminate\Bus\Batchable;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
@@ -15,7 +16,6 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
-use FlexMindSoftware\CurrencyRate\Support\Logger;
 use Illuminate\Support\Facades\Redis;
 use Throwable;
 

--- a/src/Jobs/QueueDownload.php
+++ b/src/Jobs/QueueDownload.php
@@ -15,7 +15,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
-use Illuminate\Support\Facades\Log;
+use FlexMindSoftware\CurrencyRate\Support\Logger;
 use Illuminate\Support\Facades\Redis;
 use Throwable;
 
@@ -93,7 +93,7 @@ class QueueDownload implements ShouldQueue, ShouldBeUnique, ShouldBeUniqueUntilP
                         CurrencyRateModel::saveIn($data, $this->databaseConnection);
                     }
                 } catch (Throwable $exception) {
-                    Log::error(
+                    Logger::error(
                         'QueueDownload job failed: ' . $exception->getMessage(),
                         $exception->getTrace()
                     );

--- a/src/Support/Logger.php
+++ b/src/Support/Logger.php
@@ -25,4 +25,3 @@ class Logger
         return self::channel()->{$name}(...$arguments);
     }
 }
-

--- a/src/Support/Logger.php
+++ b/src/Support/Logger.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlexMindSoftware\CurrencyRate\Support;
+
+use Illuminate\Support\Facades\Log;
+use Psr\Log\LoggerInterface;
+
+class Logger
+{
+    private static function channel(): LoggerInterface
+    {
+        $channel = config('currency-rate.log_channel');
+
+        if ($channel === null) {
+            $channel = config('logging.default');
+        }
+
+        return Log::channel($channel);
+    }
+
+    public static function __callStatic(string $name, array $arguments)
+    {
+        return self::channel()->{$name}(...$arguments);
+    }
+}
+

--- a/tests/LoggerTest.php
+++ b/tests/LoggerTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlexMindSoftware\CurrencyRate\Tests;
+
+use FlexMindSoftware\CurrencyRate\Support\Logger;
+use Illuminate\Support\Facades\Log;
+use Psr\Log\LoggerInterface;
+
+class LoggerTest extends TestCase
+{
+    /**
+     * @test
+     * @return void
+     */
+    public function it_sends_logs_to_the_configured_channel()
+    {
+        config(['currency-rate.log_channel' => 'custom']);
+
+        $mock = \Mockery::mock(LoggerInterface::class);
+        $mock->shouldReceive('error')->once()->with('test');
+
+        Log::shouldReceive('channel')->once()->with('custom')->andReturn($mock);
+
+        Logger::error('test');
+    }
+}
+

--- a/tests/LoggerTest.php
+++ b/tests/LoggerTest.php
@@ -26,4 +26,3 @@ class LoggerTest extends TestCase
         Logger::error('test');
     }
 }
-

--- a/tests/QueueDownloadTest.php
+++ b/tests/QueueDownloadTest.php
@@ -47,6 +47,7 @@ class QueueDownloadTest extends TestCase
      */
     public function handle_logs_exception()
     {
+        Log::shouldReceive('channel')->andReturnSelf();
         Log::shouldReceive('error')->once();
 
         $job = new QueueDownload('missing', new DateTimeImmutable(), 'testing');


### PR DESCRIPTION
## Summary
- allow configuring a dedicated log channel via `currency-rate.log_channel`
- add `Support\Logger` wrapper that selects channel or falls back to Laravel's default
- refactor logging in commands, jobs and drivers to use the new logger
- document the new option
- cover logging behavior with unit tests

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68af070758408333868e5d016caba225