### PR TITLE
Validate driver classes during boot

### DIFF
--- a/src/CurrencyRateServiceProvider.php
+++ b/src/CurrencyRateServiceProvider.php
@@ -7,6 +7,7 @@ namespace FlexMindSoftware\CurrencyRate;
 use FlexMindSoftware\CurrencyRate\Commands\CurrencyRateCommand;
 use FlexMindSoftware\CurrencyRate\Drivers\UnitedStatesDriver;
 use InvalidArgumentException;
+use Illuminate\Support\Str;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 
@@ -44,6 +45,14 @@ class CurrencyRateServiceProvider extends PackageServiceProvider
         $this->app->bind(UnitedStatesDriver::class, fn ($app) => new UnitedStatesDriver());
     }
 
+    /**
+     * @return void
+     */
+    public function packageBooted(): void
+    {
+        $this->validateDrivers();
+    }
+
     protected function validateConfig(): void
     {
         $required = ['driver', 'table-name', 'drivers'];
@@ -52,6 +61,19 @@ class CurrencyRateServiceProvider extends PackageServiceProvider
             if (! config()->has("currency-rate.$key") || empty(config("currency-rate.$key"))) {
                 throw new InvalidArgumentException(
                     "currency-rate configuration missing required key [$key]."
+                );
+            }
+        }
+    }
+
+    protected function validateDrivers(): void
+    {
+        foreach (config('currency-rate.drivers', []) as $driver) {
+            $class = 'FlexMindSoftware\\CurrencyRate\\Drivers\\'.Str::studly($driver).'Driver';
+
+            if (! class_exists($class)) {
+                throw new InvalidArgumentException(
+                    "Driver class [$class] for driver [$driver] does not exist."
                 );
             }
         }

--- a/tests/DriverValidationTest.php
+++ b/tests/DriverValidationTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlexMindSoftware\CurrencyRate\Tests;
+
+use FlexMindSoftware\CurrencyRate\CurrencyRateServiceProvider;
+use InvalidArgumentException;
+
+class DriverValidationTest extends TestCase
+{
+    protected function getPackageProviders($app)
+    {
+        return [];
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_exception_for_missing_driver_class(): void
+    {
+        $this->app['config']->set('currency-rate', [
+            'driver' => 'non-existing-driver',
+            'drivers' => ['non-existing-driver'],
+            'table-name' => 'currency_rates',
+        ]);
+
+        $provider = new CurrencyRateServiceProvider($this->app);
+        $provider->packageRegistered();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Driver class [FlexMindSoftware\\CurrencyRate\\Drivers\\NonExistingDriverDriver] for driver [non-existing-driver] does not exist.');
+
+        $provider->packageBooted();
+    }
+}
+


### PR DESCRIPTION
## Summary
- validate configuration drivers by ensuring each driver class exists when the package boots
- add test ensuring missing driver throws InvalidArgumentException

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68af06ee01a88333865beffc44028eb6