### PR TITLE
feat: add logger to drivers

### DIFF
--- a/src/Drivers/BotswanaDriver.php
+++ b/src/Drivers/BotswanaDriver.php
@@ -8,7 +8,6 @@ use DateTimeImmutable;
 use FlexMindSoftware\CurrencyRate\Contracts\CurrencyInterface;
 use FlexMindSoftware\CurrencyRate\Enums\CurrencyCode;
 use FlexMindSoftware\CurrencyRate\Models\RateTrait;
-use FlexMindSoftware\CurrencyRate\Support\Logger;
 
 class BotswanaDriver extends BaseDriver implements CurrencyInterface
 {

--- a/src/Drivers/HttpFetcher.php
+++ b/src/Drivers/HttpFetcher.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace FlexMindSoftware\CurrencyRate\Drivers;
 
 use FlexMindSoftware\CurrencyRate\Support\CacheFactory;
+use FlexMindSoftware\CurrencyRate\Support\Logger;
 use GuzzleHttp\Psr7\Request;
 use Illuminate\Support\Facades\Http;
 use Psr\Http\Client\ClientInterface;
@@ -28,10 +29,18 @@ trait HttpFetcher
         // --- CACHE KEY (kolejność parametrów nie ma znaczenia)
         ksort($query);
         $key = 'currency-rate:' . $url . (empty($query) ? '' : '?' . http_build_query($query));
+        $driver = defined('static::DRIVER_NAME') ? static::DRIVER_NAME : static::class;
+
+        Logger::debug('Fetching data', [
+            'driver' => $driver,
+            'url' => $url,
+            'query' => $query,
+        ]);
 
         $cache = CacheFactory::make();
 
         if ($cache->has($key)) {
+            Logger::debug('Fetch cache hit', ['key' => $key]);
             return $cache->get($key);
         }
 
@@ -68,6 +77,7 @@ trait HttpFetcher
                 }
 
                 if ($body !== null) {
+                    Logger::debug('Fetch succeeded', ['url' => $url, 'query' => $query]);
                     $cache->put($key, $body, (int) config('currency-rate.cache-ttl'));
 
                     return $body;
@@ -77,6 +87,13 @@ trait HttpFetcher
                 throw new \RuntimeException('Request failed with non-2xx status');
             } catch (Throwable $e) {
                 $exception = $e;
+                Logger::warning('Fetch attempt failed', [
+                    'driver' => $driver,
+                    'attempt' => $attempt,
+                    'url' => $url,
+                    'query' => $query,
+                    'exception' => $e,
+                ]);
 
                 if ($attempt >= $tries) {
                     break; // koniec prób
@@ -89,6 +106,14 @@ trait HttpFetcher
                 }
             }
         }
+
+        Logger::error('Fetch failed after all retries', [
+            'driver' => $driver,
+            'url' => $url,
+            'query' => $query,
+            'attempts' => $attempt,
+            'exception' => $exception,
+        ]);
 
         // po wszystkich próbach zwracamy null (bez rzucania dalej)
         return null;

--- a/src/Drivers/HttpFetcher.php
+++ b/src/Drivers/HttpFetcher.php
@@ -41,6 +41,7 @@ trait HttpFetcher
 
         if ($cache->has($key)) {
             Logger::debug('Fetch cache hit', ['key' => $key]);
+
             return $cache->get($key);
         }
 


### PR DESCRIPTION
## Summary
- centralize driver logging in `HttpFetcher` with debug, warning, and error events
- remove unused `Logger` imports from individual drivers while retaining database error logging in `BaseDriver`

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68af0b9b844483338effe9b9842c206a